### PR TITLE
Add fdri:originatingFacility property to ObservationDataset

### DIFF
--- a/ontology/doc/high-level-catalog-structure.md
+++ b/ontology/doc/high-level-catalog-structure.md
@@ -107,6 +107,8 @@ Related datasets are gathered together using the DCAT `dcat:DatasetSeries` type 
 
 The property `fdri:originatingFacility` can be used to reference the `EnvironmentalMonitoringFacility` from which observations contained in the dataset have come. The choice of facility should be a facility  permanently associated with the observations in the dataset, so prefer the site at which the sensor equipment is located over sensors or packages which may be replaced without starting a new dataset. This property may also be used with `fdri:ObservationDatasetSeries` in which case the referenced facility should be the `EnvironmentalMonitoringSite` for a series soft-typed as `SiteDatasetSeries`, or the `EnvironmentalMonitoringStation` for series soft-typed as `StationDatasetSeries`.
 
+The property `fdri:originatingProgramme` can be used to reference the `EnvironmentalMonitoringProgramme` from which observations contained in the dataset have come. This provides a more direct way to group datasets from the same programme than going via the `fdri:ProgrammeCatalog`
+
 > **NOTE**
 > The use of dataset-level quality metric observations can be reserved for aggregate metrics such as data availability metrics. Row-level metrics could (and arguably should) be managed in the underlying data store.
 
@@ -117,6 +119,7 @@ The property `fdri:originatingFacility` can be used to reference the `Environmen
   class ConceptScheme["skos:ConceptScheme"]
   class ObservedProperty["fdri:ComplexObservableProperty"]
   class Program["fdri:EnvironmentalMonitoringProgramme"]
+  class Facility["fdri:EnvironmentalMonitoringFacility"]
   class Agent["fdri:Agent"]
   class GeospatialFeatureOfInterest["frdi:GeospatialFeatureOfInterest"]
   class QualityObservation["fdri:QualityObservation"]
@@ -156,7 +159,8 @@ The property `fdri:originatingFacility` can be used to reference the `Environmen
   ObservationDataset <|-- ObservationDatasetSeries
   CatalogResource --> Concept: dct_theme
   ObservationDataset --> ObservedProperty: sosa_observedProperty
-  ObservationDataset --> EnvironmentalMonitoringFacility: fdri_originatingFacility
+  ObservationDataset --> Facility: fdri_originatingFacility
+  ObservationDataset --> Program: fdri_originatingProgramme
   CatalogResource --> Agent: dct_creator
   CatalogResource --> Agent: dct_publisher
   DatasetSeries --|> Dataset

--- a/ontology/owl/fdri-metadata.ttl
+++ b/ontology/owl/fdri-metadata.ttl
@@ -218,6 +218,12 @@
                      rdfs:comment "Relates a dataset of observations to the Environmental Monitoring Facility from which the observations originated. The choice of facilit(ies) to use as the value of this property should be restricted to those which apply to all observations in the temporal range of the dataset (such as a site or a platform), and not to facilities which might be replaced over the time span of the dataset (such as a replacable sensor or sensor package)."@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/originatingProgramme
+:originatingProgramme rdf:type owl:ObjectProperty ;
+                      rdfs:domain :ObservationDataset ;
+                      rdfs:range :EnvironmentalMonitoringProgramme .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/parameter
 :parameter rdf:type owl:ObjectProperty ;
            rdfs:subPropertyOf owl:topObjectProperty ;
@@ -1006,6 +1012,10 @@
                                     ] ,
                                     [ rdf:type owl:Restriction ;
                                       owl:onProperty :originatingFacility ;
+                                      owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :originatingProgramme ;
                                       owl:minCardinality "0"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;

--- a/sample_data/schema/fdri.recordspec.yaml
+++ b/sample_data/schema/fdri.recordspec.yaml
@@ -1056,6 +1056,12 @@ records:
         repeatable: true
         constraints:
           - record: EnvironmentalMonitoringFacility
+      originatingProgramme:
+        propertyUri: fdri:originatingProgramme
+        kind: object
+        repeatable: true
+        constraints:
+          - record: EnvironmentalMonitoringProgramme
       isVersionOf:
         propertyUri: dct:isVersionOf
         kind: object


### PR DESCRIPTION
Implements #48 using the new property `fdri:originatingFacility` with range `fdri:EnvironmentalMonitoringFacility` which allows a dataset to be related to any `fdri:EnvironmentalMonitoringFacility` (includes sites, stations and system)