### PR TITLE
Add processing level metadata to time-series

### DIFF
--- a/sample_data/Makefile
+++ b/sample_data/Makefile
@@ -33,7 +33,8 @@ SAMPLES = \
 	build/CORRECTION_FACTORS.ttl \
 	build/PARAMETER_RANGES_QC.ttl \
 	build/Firmware_history.ttl \
-	build/sensorFaultsSplit.ttl
+	build/sensorFaultsSplit.ttl \
+	build/processingLevels.ttl
 
 SCHEMAS = $(RECORDS:%=build/schema/%.schema.json)
 

--- a/sample_data/src/processingLevels.csv
+++ b/sample_data/src/processingLevels.csv
@@ -1,0 +1,7 @@
+ID,LABEL
+raw,Raw
+0,Level 0
+1,Level 1
+2,Level 2
+3,Level 3
+mixed,Mixed Levels

--- a/sample_data/templates/processingLevels.yaml
+++ b/sample_data/templates/processingLevels.yaml
@@ -1,0 +1,24 @@
+globals:
+  $baseURI: http://fdri.ceh.ac.uk/
+  $datasetID: cosmos
+
+imports:
+  - namespaces.yaml
+  - extensions.py
+
+one_offs:
+  - name: ProcessingLevelScheme
+    properties:
+      "@id": <http://fdri.ceh.ac.uk/ref/common/processing-level>
+      "@type": <fdri:ProcessingLevelScheme>
+      "<dct:title>": "FDRI Data Processing Levels@en"
+      "<rdfs:label>": "FDRI Data Processing Levels@en"
+
+resources:
+  - name: ProcessingLevel
+    properties:
+      "@id": <http://fdri.ceh.ac.uk/ref/common/processing-level/{ID|slug}>
+      "@type": <fdri:ProcessingLevel>
+      "<skos:prefLabel>": "{LABEL}@en"
+      "<skos:inScheme>": <::ProcessingLevelScheme>
+      "^<skos:hasTopConcept>": <::ProcessingLevelScheme>

--- a/sample_data/templates/siteInstVar.yaml
+++ b/sample_data/templates/siteInstVar.yaml
@@ -36,6 +36,8 @@ resources:
       "<dct:title>": "All Time Series for {VARIABLE_NAME} from site {SITE_ID}@en"
       "<sosa:hasFeatureOfInterest>": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}>"
       "<dct:spatial>": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}>"
+      "<fdri:processingLevel>": <http://fdri.ceh.ac.uk/ref/common/processing-level/mixed>
+      "<sosa:observedProperty>": <http://fdri.ceh.ac.uk/ref/cosmos/cop/{VARIABLE_NAME|slug}>
 
   - name: Feature
     properties:
@@ -51,6 +53,8 @@ resources:
       "<dcat:inSeries>": 
         - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}>"
         - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{VARIABLE_NAME|slug}-raw>"
+      "<fdri:processingLevel>": <http://fdri.ceh.ac.uk/ref/common/processing-level/raw>
+      "<sosa:observedProperty>": <http://fdri.ceh.ac.uk/ref/cosmos/cop/{VARIABLE_NAME|slug}>
       "<prov:wasGeneratedBy>":
         name: IngestActivity
         properties:
@@ -69,6 +73,8 @@ resources:
       "<dcat:inSeries>":
         - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}>"
         - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{VARIABLE_NAME|slug}-infill>"
+      "<fdri:processingLevel>": <http://fdri.ceh.ac.uk/ref/common/processing-level/2>
+      "<sosa:observedProperty>": <http://fdri.ceh.ac.uk/ref/cosmos/cop/{VARIABLE_NAME|slug}>
       "<prov:wasGeneratedBy>":
         name: QCInfillActivity
         properties:
@@ -78,6 +84,7 @@ resources:
           "<prov:used>": <::RawSeries>
           "<prov:startedAt>": "2024-11-26T10:00:00Z^^<xsd:dateTime>"
           "<prov:endedAt>": "2024-11-26T10:03:33Z^^<xsd:dateTime>"
+          "<fdri:processingLevel>": <http://fdri.ceh.ac.uk/ref/common/processing-level/2>
           "<prov:qualifiedAssociation>":
             - name: PreprocessingStep
               properties:
@@ -132,14 +139,14 @@ resources:
       "@type": "<fdri:Deployment>"
       "<dct:description>": "{COMMENTS}@en"
 
-  - name: ObservedProperty
-    requires:
-      VARIABLE_NAME:
-      PROPERTY:
-    properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/cop/{VARIABLE_NAME|slug}>"
-      "@type": "<fdri:ComplexObservableProperty>"
-      "^<sosa:observedProperty>":
-        - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}>"
-        - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}-raw>"
-        - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}-infill>"
+  # - name: ObservedProperty
+  #   requires:
+  #     VARIABLE_NAME:
+  #     PROPERTY:
+  #   properties:
+  #     "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/cop/{VARIABLE_NAME|slug}>"
+  #     "@type": "<fdri:ComplexObservableProperty>"
+  #     "^<sosa:observedProperty>":
+  #       - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}>"
+  #       - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}-raw>"
+  #       - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}-infill>"


### PR DESCRIPTION
Add a dummy set of processing level concepts (raw, 0, 1, 2, 3 and mixed) and link in generated time-series.
The `mixed` value is used only for dataset series that consist of time-series with different levels of data processing applied to them.