### PR TITLE
Fix generated site ID

### DIFF
--- a/sample_data/templates/siteVariance.yaml
+++ b/sample_data/templates/siteVariance.yaml
@@ -4,10 +4,11 @@ globals:
 
 imports:
     - namespaces.yaml
+    - extensions.py
 
 resources:
     - name: MonitoringSite
       properties:
-        "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/site/{SITE_ID}>"
+        "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/site/{SITE_ID|slug}>"
         "@type": <fdri:EnvironmentalMonitoringSite>
         "<fdri:siteVariance>": "{STANDARD_LAYOUT}@en"


### PR DESCRIPTION
Fix the URI assigned to sites by the siteVariance template to match the IDs generated elsewhere