### PR TITLE
Update sample data generation to include dcat:temporalResolution 

### DIFF
--- a/sample_data/sql/siteInstVar.sql
+++ b/sample_data/sql/siteInstVar.sql
@@ -2,11 +2,12 @@ create table IF NOT EXISTS site_inst as from read_csv('./src/SITE_INSTRUMENTATIO
 create table IF NOT EXISTS var_inst as from read_csv('./src/VARIABLE_INSTRUMENTATION.csv', AUTO_DETECT=true) ;
 create table if not EXISTS var_prop as from read_csv('./src/variableProperties.csv', AUTO_DETECT=true) ;
 COPY(
-    SELECT site_inst.*, var_inst.*, var_prop.PROPERTY
+    SELECT site_inst.*, var_inst.*, var_prop.PROPERTY, var_prop.INTERVAL
     FROM site_inst
     INNER JOIN var_inst 
     ON site_inst.INSTRUMENT_ID=var_inst.INSTRUMENT_ID
     LEFT JOIN var_prop
     ON var_inst.VARIABLE_NAME=var_prop.VARIABLE_NAME
+    WHERE site_inst.INSTRUMENT_ID != 'DERIVED'
     ORDER BY SITE_ID, site_inst.INSTRUMENT_ID, START_DATETIME
 ) TO './build/siteInstVar.csv' (HEADER, DELIMITER ',') ;

--- a/sample_data/templates/siteInstVar.yaml
+++ b/sample_data/templates/siteInstVar.yaml
@@ -58,6 +58,7 @@ resources:
       "@type": <fdri:TimeSeriesDataset>
       "<dct:title>": "Raw Time Series for {VARIABLE_NAME} at site {SITE_ID}@en"
       "<dct:spatial>": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}>"
+      "<dcat:temporalResolution>": "{INTERVAL}^^<xsd:duration>"
       "<dcat:inSeries>": 
         - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}>"
         - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{VARIABLE_NAME|slug}-raw>"
@@ -81,6 +82,7 @@ resources:
       "@type": <fdri:TimeSeriesDataset>
       "<dct:title>": "In-filled Time Series for {VARIABLE_NAME} at site {SITE_ID}@en"
       "<dct:spatial>": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}>"
+      "<dcat:temporalResolution>": "{INTERVAL}^^<xsd:duration>"
       "<dcat:inSeries>":
         - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{SITE_ID|slug}-{VARIABLE_NAME|slug}>"
         - "<http://fdri.ceh.ac.uk/id/dataset/cosmos-{VARIABLE_NAME|slug}-infill>"


### PR DESCRIPTION
* Update generation template for time-series datasets to include the temporal resolution. As these are all unaggregated datasets, the temporal resolution will match the aggregation period of the relevant observed property. 
