### PR TITLE
Make fdri:EnvironmentalMonitoringSite extends sosa:Platform

### DIFF
--- a/ontology/owl/fdri-metadata.ttl
+++ b/ontology/owl/fdri-metadata.ttl
@@ -842,6 +842,7 @@
 ###  http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringSite
 :EnvironmentalMonitoringSite rdf:type owl:Class ;
                              rdfs:subClassOf :EnvironmentalMonitoringFacility ,
+                                             <http://www.w3.org/ns/sosa/Platform> ,
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty <http://www.w3.org/ns/sosa/hosts> ;
                                                owl:allValuesFrom <http://www.w3.org/ns/sosa/Platform>

--- a/sample_data/schema/fdri.recordspec.yaml
+++ b/sample_data/schema/fdri.recordspec.yaml
@@ -1191,6 +1191,7 @@ records:
         kind: object
         constraints:
           - record: EnvironmentalMonitoringPlatform
+          - record: EnvironmentalMonitoringSite
       deployedSystem:
         label:
           - value: deployed system

--- a/sample_data/templates/SITES.yaml
+++ b/sample_data/templates/SITES.yaml
@@ -377,22 +377,6 @@ resources:
                   "@id": "<_>"
                   "@type": "<schema:PropertyValue>"
                   "<schema:value>": "{HOST_CLASS | asDecimal}"
-
-
-    - name: MonitoringPlatform
-      properties:
-        "@id": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}>"
-        "@type": <fdri:EnvironmentalMonitoringPlatform>
-        "<rdfs:label>": "COSMOS monitoring station at {SITE_NAME}@en"
-        "<dct:isPartOf>": "<http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}>"
-        "^<dct:hasPart>": "<http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}>"
-        "<geos:hasGeometry>":
-            - name: LatLongPoint
-              properties:
-                "@id": "<_>"
-                "@type": "<geos:Geometry>"
-                "<geos:asWKT>": "POINT({LONGITUDE}, {LATITUDE})^^<geos:wktLiteral>"
-        "<fdri:hasAnnotation>":
           - name: Calibrated
             properties:
               "@id": "<_>"

--- a/sample_data/templates/siteInstVar.yaml
+++ b/sample_data/templates/siteInstVar.yaml
@@ -136,7 +136,7 @@ resources:
       "@type": "<fdri:Deployment>"
       "<dct:title>": "Deployment of {INSTRUMENT_ID} {SERIAL_NUMBER} at {SITE_ID}@en"
       "<ssn:deployedSystem>": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
-      "<ssn:deployedOnPlatform>": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}>"
+      "<ssn:deployedOnPlatform>": "<http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}>"
       "<prov:startedAtTime>": "{START_DATETIME|asDateTime}"
   - name: SensorDeploymentEnd
     requires:


### PR DESCRIPTION
* Update OWL ontology so that fdri:EnvironmentalMonitoringSite is a subclass of sosa:Platform.
* Update the schema to allow an fdri:EnvironmentalMonitoringSite to be the target of the sosa:deployedOnPlatform property of sosa:Deployment
* Update the generated sample data to use the simplified structure with deployments being on sites 
Closes #73