### PR TITLE
Change to ceh auth

### DIFF
--- a/.github/workflows/publish-data.yaml
+++ b/.github/workflows/publish-data.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: eu-west-2
+          aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2


### PR DESCRIPTION
Uses build tool from Epimorphics ECR which should now allow federated access from CEH account.