### PR TITLE
Remove direct properties for soilType and landCover

### DIFF
--- a/ontology/owl/fdri-metadata.ttl
+++ b/ontology/owl/fdri-metadata.ttl
@@ -192,11 +192,6 @@ above the local reference ellipsoid).""" ;
           rdfs:range <http://purl.org/dc/terms/PeriodOfTime> .
 
 
-###  http://fdri.ceh.ac.uk/vocab/metadata/landCover
-:landCover rdf:type owl:ObjectProperty ;
-           rdfs:subPropertyOf :temporallyValidProperty .
-
-
 ###  http://fdri.ceh.ac.uk/vocab/metadata/member
 :member rdf:type owl:ObjectProperty ;
         rdfs:range :EnvironmentalMonitoringFacility .
@@ -293,19 +288,8 @@ above the local reference ellipsoid).""" ;
                        rdfs:range <http://www.w3.org/2006/vcard/ns#Kind> .
 
 
-###  http://fdri.ceh.ac.uk/vocab/metadata/soilType
-:soilType rdf:type owl:ObjectProperty ;
-          rdfs:subPropertyOf owl:topObjectProperty ;
-          rdfs:range :SoilType .
-
-
 ###  http://fdri.ceh.ac.uk/vocab/metadata/status
 :status rdf:type owl:ObjectProperty .
-
-
-###  http://fdri.ceh.ac.uk/vocab/metadata/temporallyValidProperty
-:temporallyValidProperty rdf:type owl:ObjectProperty ;
-                         rdfs:range :PropertyValueSeries .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/trackLog
@@ -923,14 +907,6 @@ above the local reference ellipsoid).""" ;
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty <http://www.w3.org/ns/sosa/hosts> ;
                                                owl:allValuesFrom <http://www.w3.org/ns/sosa/Platform>
-                                             ] ,
-                                             [ rdf:type owl:Restriction ;
-                                               owl:onProperty :landCover ;
-                                               owl:minCardinality "0"^^xsd:nonNegativeInteger
-                                             ] ,
-                                             [ rdf:type owl:Restriction ;
-                                               owl:onProperty :soilType ;
-                                               owl:minCardinality "1"^^xsd:nonNegativeInteger
                                              ] ,
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty :siteVariance ;

--- a/sample_data/schema/fdri.recordspec.yaml
+++ b/sample_data/schema/fdri.recordspec.yaml
@@ -1633,19 +1633,6 @@ records:
         kind: literal
         constraints:
           - datatype: xsd:decimal
-      landCover:
-        label:
-          - value: land cover
-            lang: en
-        description:
-          - value: A record of the land cover/land usage at the site over time.
-            lang: en
-        propertyUri: fdri:landCover
-        kind: object
-        nested: true
-        repeatable: true
-        constraints:
-          - record: PropertyValueSeries
       siteVariance:
         label:
           - value: site variance
@@ -1659,18 +1646,6 @@ records:
         repeatable: true
         constraints:
           - datatype: rdf:langString
-      soilType:
-        label:
-          - value: soil type
-            lang: en
-        description:
-          - value: |
-              The clasification of the type of soil found at this site.
-            lang: en
-        propertyUri: fdri:soilType
-        kind: object
-        constraints:
-          - record: SoilType
   
   EnvironmentalMonitoringSystem:
     label:


### PR DESCRIPTION
Addresses #61. These properties should be recorded as annotations instead of as direct properties