### PR TITLE
Add a test workflow

### DIFF
--- a/.github/workflows/test-data.yaml
+++ b/.github/workflows/test-data.yaml
@@ -1,6 +1,7 @@
 name: test sample data generation
 on:
   pull_request:
+  workflow_dispatch: 
 
 permissions:
   contents: read


### PR DESCRIPTION
Add a test workflow to validate that the sample data build runs without failures.
The workflow will store the SHACL validation results as an artefact to allow them to be downloaded for local inspection.