### PR TITLE
Script to generate HTML model documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ DuckDB.session.sql
 
 # LibreOffice
 .~lock.*
+
+# Generated Files
+ontology/doc/html/*.html
+ontology/doc/html/*.png

--- a/ontology/doc/emf.md
+++ b/ontology/doc/emf.md
@@ -1,6 +1,6 @@
-# Environmental Monitoring Facility Model
+## Environmental Monitoring Facility Model
 
-## Programme, Network and Facility
+### Programme, Network and Facility
 
 Based on the [INSPIRE Environmental Monitoring Facility Technical Guidelines framework](https://inspire-mif.github.io/technical-guidelines/data/ef/dataspecification_ef.pdf), the catalog models  reference information about infrastructure such as sites, stations, and drones using the `fdri:EnvironmentalMonitoringFacility` class.
 
@@ -75,7 +75,7 @@ Facility --> Activity: prov_wasInvalidatedBy
 Facility --> Facility: dct_hasPart
 ```
 
-## Site, Platform, System and Sensor
+### Site, Platform, System and Sensor
 
 The `fdri:EnvironmentalMonitoringFacility` class has several subclasses defined to aid in mapping to the SOSA/SSN concepts of Platform, System and Sensor. The diagram below shows the relationship between the FDRI types and the mapping (via subclass relationships) to the SOSA/SSN types.
 
@@ -102,7 +102,7 @@ Site --|> SosaPlatform
 Platform --|> SosaPlatform
 ```
 
-### EnvironmentalMonitoringSite
+#### EnvironmentalMonitoringSite
 
 `fdri:EnvironmentalMonitoringSite` is used to represent a static geospatial location at which one or more pieces of monitoring infrastructure may be deployed. It is subclassed from `fdri:EnvironmentalMonitoringFacility` and so has all the same core metadata that is provided by that class, but it is also mapped through a subclass relationship to the `sosa:Platform` type from the SOSA/SSN vocabulary which means that it can be the host of a deployment of a sensor or system of sensors. 
 
@@ -162,7 +162,7 @@ PropertyValue --> Unit: schema_unit
 > Should all measures such as altitude be expressed as a `schema:PropertyValue` value with units, or do we bake the assumed units into the ontology?
 
 
-### EnvironmentalMonitoringPlatform
+#### EnvironmentalMonitoringPlatform
 
 `fdri:EnvironmentalMonitoringPlatform` is used to represent either static or mobile infrastructure on which sensors or systems of sensors may be deployed. Examples include a post in the ground at a site, or a UAV or drone. It is subclassed from `fdri:EnvironmentalMonitoringFacility` to inherit the core facility metadata, and mapped to `sosa:Platform` to allow it to be the host of deployments of sensors.
 
@@ -170,7 +170,7 @@ PropertyValue --> Unit: schema_unit
 > By mapping both `fdri:EnvironmentalMonitoringSite` and `fdri:EnvironmentalMonitoringPlatform` to `sosa:Platform`, a deployment of a sensor can be registered at the site level without having to model the detail of the physical infrastructure at the site, but that the model still has the flexibility to represent more detailed information if it is available and if deemed desireable to do so.
 
 
-### EnvironmentalMonitoringSystem
+#### EnvironmentalMonitoringSystem
 
 An `fdri:EnvironmentalMonitoringSystem` is a device which measures properties in the environment. As already noted, an `fdri:EnvironmentalMonitoringSystem` may be deployed either to an `fdri:EnvironmentalMonitoringPlatform` or directly to an `fdri:EnvironmentalMonitoringSite`.
 
@@ -193,13 +193,13 @@ class System["fdri:EnvironmentalMonitoringSystem"] {
 System --> System: sosa_hasSubsystem
 ```
 
-### EnvironmentalMonitoringSensor
+#### EnvironmentalMonitoringSensor
 
 An `fdri:EnvironmentalMonitoringSensor` is intended to represent an individual sensor and is subclassed from `sosa:Sensor` and may be deployed either to an `fdri:EnvironmentalMonitoringPlatform` or directly to an `fdri:EnvironmentalMonitoringSite`.
 
 As `fdri:EnvironmentalMonitoringSensor` is subclassed from `fdri:EnvironmentalMonitoringSystem` it also inherits the additional metadata shown for that class and faults can be recorded against individual sensors.
 
-## Geo-Spatial Feature Of Interest
+### Geo-Spatial Feature Of Interest
 
 An `fdri:EnvironmentalMonitoringFacility` monitors some set of features of the environment. Where those features are spatially located, the class `fdri:GeospatialFeatureOfInterest` may be used to represent them.
 
@@ -224,7 +224,7 @@ The properties of `fdri:GeospatialFeatureOfInterest` provide ways of describing 
 
 As already shown, the `GeospatialFeatureOfInterest` may also be referenced from the `Dataset` which contains observations of that feature.
 
-## FacilityGroup
+### FacilityGroup
 
 A `FacilityGroup` is an unordered collection of `EnvironmentalMonitoringFacility` instances that share some common feature. A `FacilityGroup` is treated as a `Resource` in the metadata catalog and so may have a title, provenance and publication information and so on.
 

--- a/ontology/doc/geospatial.md
+++ b/ontology/doc/geospatial.md
@@ -1,4 +1,4 @@
-# Notes on Geo-spatial Resources
+## Notes on Geo-spatial Resources
 
 Several classes in the FDRI ontology represent geo-spatially located entities which are either persistent or temporary in nature. In particular `fdri:EnvironmentalMonitoringFacility`, `fdri:GeospatialFeature` and `fdri:MobileDeployment`. To facilitate a range of both machine and human access to geospatial data relating to these entities the model provides a number of distinct properties on these classes.
 

--- a/ontology/doc/html/normalize.css
+++ b/ontology/doc/html/normalize.css
@@ -1,0 +1,349 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+html {
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Remove the margin in all browsers.
+ */
+
+body {
+  margin: 0;
+}
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+
+main {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+
+img {
+  border-style: none;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Misc
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10+.
+ */
+
+template {
+  display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+
+[hidden] {
+  display: none;
+}

--- a/ontology/doc/html/styles.css
+++ b/ontology/doc/html/styles.css
@@ -1,0 +1,203 @@
+:root {
+    --accent-color: #005a9c;
+    --light-accent-color: #f0f8ff;
+    --heading-text: #005a9c;
+    --table-border: 2px solid var(--heading-text);
+    --table-header-border: 1px solid lightgray;
+    --font-monospace: 'Courier New', Courier, monospace;
+    --code-color: #b22222;
+}
+
+body {  
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    line-height: 1.5;
+}
+
+nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: auto;
+    bottom: 0;
+    width: 25%;
+    overflow: auto;
+    padding-left: 1.5em;
+}
+
+/* Body Header Styles */
+h1, h2, h3, h4, h5, h6 {
+    color: var(--heading-text);
+}
+h2,h3,h4,h5,h6 {
+    margin-top: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+h1 { font-size: x-large; font-weight: bold;}
+h2 { font-size: large; font-weight: bold;}
+h3 { font-size: medium; font-weight: bold;}
+h4 { font-size: medium; font-weight: normal;}
+
+/* Tables */
+table {
+    table-layout: fixed;
+    width: 100%;
+    border-collapse: collapse;
+    border: var(--table-border);
+    margin-bottom: 1rem;
+}
+th, td {
+    padding: 0.75rem;
+    text-wrap-mode: wrap;
+    text-wrap: pretty;
+}
+td > p:first-child {
+    margin-block-start: 0;
+}
+
+td > p:last-child {
+    margin-block-end: 0;
+}
+td > ul:first-child {
+    margin-block-start: 0;
+}
+
+thead th {
+    border-bottom: var(--table-header-border);
+}
+
+tbody th {
+    border-right: var(--table-header-border);
+    width: 10rem;
+    vertical-align: top;
+}
+
+tbody tr:nth-child(odd) {
+    background-color: var(--light-accent-color);
+}
+
+code {
+    display: inline-block;
+    font-family: var(--font-monospace);
+    font-size: 0.875em;
+    color: var(--code-color);
+}
+/* Links as inline blocks to remove trailing whitespace */
+a {
+    display: inline-block;
+}
+/* Links to Ontology Entities */
+a.entity, a.entity:visited {
+    font-family: var(--font-monospace);
+    font-size: 0.875em;
+    color: var(--code-color);
+}
+
+/* Mermaid diagrams */
+.mermaid {
+    margin-bottom: 1rem;
+}
+
+/* Blockquotes */
+blockquote {
+    margin-left: 1rem;
+    border-left: 1rem solid var(--accent-color);
+    padding: 0.2rem 0.5rem 0.2rem 0.5rem;
+    background-color: var(--light-accent-color);
+}
+
+/* Definition Lists */
+dl {
+    display: grid;
+    grid-template-columns: auto 1fr;
+}
+dd {
+    margin: 0 0 0 0.5rem;
+}
+/* pyLODE Annotations */
+.sup-c {
+    color: orange;
+}
+
+.sup-op {
+    color: navy;
+}
+
+.sup-dp {
+    color: green;
+}
+
+.sup-ap {
+    color: darkred;
+}
+
+/* Navigation font styles */
+
+nav > .h2, .h3, .h4, .h5, .h6 {
+    font-size: 1rem;
+}
+
+.h2 {
+    font-weight: bold;
+    padding-left: 0.5em;
+}
+
+.h3 {
+    padding-left: 0.75em;
+}
+.h4, .h5, .h6 {
+    padding-left: 1.0em;
+    font-size: 95%;
+}
+
+main {
+    padding-left: calc(25% + 3em)
+}
+
+/* Navigation link style */
+nav a, a:visited {
+    color: inherit;
+    text-decoration: none;
+}
+
+nav a:hover {
+    border-bottom: 2px solid var(--accent-color);
+    background-color: var(--light-accent-color);
+}
+
+/* Numbering in navigation */
+nav { counter-reset: nh2;}
+nav .h2 { counter-reset: nh3 }
+nav .h3 { counter-reset: nh4 }
+nav .h4 { counter-reset: nh5;}
+nav .h2 > a::before {
+    counter-increment: nh2;
+    content: counter(nh2) " ";
+}
+nav .h3 > a::before {
+    counter-increment: nh3;
+    content: counter(nh2) "." counter(nh3) " ";
+}
+nav .h4 > a::before {
+    counter-increment: nh4;
+    content: counter(nh2) "." counter(nh3) "." counter(nh4) " ";
+}
+
+/* Numbering in body */
+main { counter-reset: bh2;}
+main h2 { counter-reset: bh3; }
+main h3 { counter-reset: bh4; }
+
+main h2::before {
+    counter-increment: bh2;
+    content: counter(bh2) " ";
+}
+main h3::before {
+    counter-increment: bh3;
+    content: counter(bh2) "." counter(bh3) " ";
+}
+main h4::before {
+    counter-increment: bh4;
+    content: counter(bh2) "." counter(bh3) "." counter(bh4) " ";
+}
+

--- a/ontology/doc/html/toc.js
+++ b/ontology/doc/html/toc.js
@@ -1,0 +1,40 @@
+function removePylodeToc (documentRef) {
+    var documentRef = documentRef || document
+    var toc = documentRef.body.querySelector('#pylode + #toc')
+    if (toc) {
+        toc.remove()
+    }
+}
+function htmlTableOfContents (documentRef) {
+    var documentRef = documentRef || document;
+    var toc = documentRef.getElementById('toc');
+    var headings = [].slice.call(documentRef.body.querySelectorAll('h2, h3, h4, h5, h6'));
+    headings.forEach(function (heading, index) {
+        if (heading.classList.contains('notoc')) {
+            return;
+        }
+        var anchor = documentRef.createElement('a');
+        anchor.setAttribute('name', 'toc' + index);
+        anchor.setAttribute('id', 'toc' + index);
+        
+        var link = documentRef.createElement('a');
+        link.setAttribute('href', '#toc' + index);
+        heading.childNodes.forEach((child) => {
+            link.appendChild(child.cloneNode())
+        })
+        // link.textContent = heading.textContent;
+        
+        var div = documentRef.createElement('div');
+        div.setAttribute('class', heading.tagName.toLowerCase());
+        
+        div.appendChild(link);
+        toc.appendChild(div);
+        heading.parentNode.insertBefore(anchor, heading);
+    });
+}
+
+
+window.addEventListener("load", () => {
+    removePylodeToc()
+    htmlTableOfContents()
+})

--- a/ontology/doc/ogc-connected-systems.md
+++ b/ontology/doc/ogc-connected-systems.md
@@ -1,6 +1,6 @@
-# OGC Connected Systems API Specification and FDRI Model
+## OGC Connected Systems API Specification and FDRI Model
 
-## Introduction
+### Introduction
 
 This section discusses how the proposed FDRI metadata model might be aligned with the [OGC Connected Systems API standard](https://ogcapi.ogc.org/connectedsystems/). 
 
@@ -9,7 +9,7 @@ This section discusses how the proposed FDRI metadata model might be aligned wit
 
 For brevity, this document does not go into detail about the content of the OGC specification. It is assumed that the reader has read (or has access to read) the two specification documents linked to above.
 
-## Part 1 Type Mappings
+### Part 1 Type Mappings
 
 Part 1 of the OGC specification focusses on the description of the systems that measure properties of features of the environment, the properties measured and the features observed. It reuses many concepts from SOSA/SSN and so has a fairly close alignment to the proposed FDRI model.
 
@@ -32,7 +32,7 @@ The diagram below, taken from the OGC spec, shows the relevant types. Types defi
 | Property          | Variable |
 | Sampling Feature  | GeospatialFeatureOfInterest |
 
-## Part 2 Type Mappings
+### Part 2 Type Mappings
 
 NOTE: For the purpose of this discussion we limit our mappings to those related to observations and ignore actuations and events which currently have no equivalence in the FDRI data model.
 
@@ -42,13 +42,13 @@ NOTE: For the purpose of this discussion we limit our mappings to those related 
 |            | TimeSeriesDataset |
 | Observation | | No direct mapping in FDRI as the model is not intended to store observations. There is an indirect mapping to the SOSA/SSN Observation type.
 
-## Model extensibility
+### Model extensibility
 
 The OGC API schema definitions are open, so additional properties can be added to the JSON to cover domain-specific metadata.
 
-## Missing from OGC
+### Missing from OGC
 
-### Provenance
+#### Provenance
 
 The OGC specification does not directly addresss provenance information for datasets.
 
@@ -66,10 +66,10 @@ TSProc --featuresOfInterest--> Site1FoI
 TSProc --featuresOfInterest--> Site1
 ```
 
-### Sensor interventions
+#### Sensor interventions
 
 Installation and replacement could be covered by Deployment, but calibration and cleaning do not have any equivalence in the OGC API.
 
-### Data Processing Configurations
+#### Data Processing Configurations
 
 Potentially these could be modelled as procedures. The precise modelling and how it can be applied to data processing agents would depend on the related issue of representing dataset provenance relations.

--- a/ontology/doc/ogc-sensor-things.md
+++ b/ontology/doc/ogc-sensor-things.md
@@ -1,12 +1,12 @@
-# OGC SensorThings API Specification and FDRI Model
+## OGC SensorThings API Specification and FDRI Model
 
-## Introduction
+### Introduction
 
 This section discusses how the FDRI model might be aligned with the data model proposed by the [OGC SensorThings API Part 1: Sensing Version 1.1](http://www.opengis.net/doc/is/sensorthings/1.1).
 
 The SensorThings API specificiation is divided into two parts. Part 1 covers Sensing, Part 2 covers Tasking. The Sensing part is intended to address managing and retrieving observations and metadata from heterogeneous IoT sensor systems, and so is the part which FDRI might most simply align. In the following discussion, a reference to "SensorThings" or the "SensorThings API" should be taken to refer specifically to the Sensing part of the SensorThings API specification. 
 
-## Type Mappings
+### Type Mappings
 
 ![Sensor Things Entity Types diagram](sensor-things-types.png)
 
@@ -25,7 +25,7 @@ This proposal recommends the following mappings of FDRI classes to SensorThings 
 | FeatureOfInterest     | NOT MAPPED |
 | ValueCode             | NOT MAPPED |
 
-### Datastream
+#### Datastream
 
 The SensorThings `Datastream` has a partial mapping to the FDRI `TimeSeriesDataset` class. The mapping is partial because the modelling of the SensorThings `Datastream` assumes that a `Datastream` is the result of observations from a single sensor, whereas the FDRI model makes no such assumption and the relation between an FDRI `TimeSeriesDataset` and the sensor (or sensors) which produced the observations contained in the dataset is indirect. Thus an accurate mapping will only be possible for `TimeSeriesDataset` instances which are restricted to observations of a single property of a single feature of interest made by a single sensor.
 
@@ -69,7 +69,7 @@ observations
 thing
 : In the SensorThings API this relation is to a Thing in an IOT network. In the FDRI model this could be considered to be the EnvironmentalMonitoringFacility from which the TimeSeriesDataset originates. If this interpretation holds, then this relationship maps to the property `fdri:originatingFacility` on the FDRI TimeSeriesDataset.
 
-### Thing
+#### Thing
 
 In the SensorThings API the "Thing" is the physical element of the IOT infrastructure that holds one or more sensors. This maps to the FDRI concept of the EnvironmentalMonitoringFaciltiy and in particular to the sub-classes of EnvironmentalMonitoringSite and EnvironmentalMonitoringPlatform.
 
@@ -93,7 +93,7 @@ HistoricalLocation
 Datastream
 : Maps to those TimeSeriesDatasets with an `fdri:originatingFacility` of this facility or one of its parts. 
 
-### Location
+#### Location
 
 **Property Mappings**
 name
@@ -112,7 +112,7 @@ location
 things
 : Maps back to the EnvironmentalMonitoringFacility instance that has this location.
 
-### Sensor
+#### Sensor
 
 Sensor maps to the FDRI EnvironmentalMonitoringSystem type (and its sub-class EnvironmentalMonitoringSensor). 
 
@@ -137,7 +137,7 @@ metadata
 Datastream
 : The Datastreams mapped from the TimeSeriesDataset(s) with an fdri:originatingFacility which hosts a (current) deployment of this EnvironmentalMonitoringSystem
 
-### ObservedProperty
+#### ObservedProperty
 
 ObservedProperty maps to Variable in the FDRI model.
 
@@ -157,17 +157,17 @@ definition
 Datastream
 : The Datastreams mapped from those TimeSeriesDataset(s) with a sosa:observedProperty of this Variable.
 
-### HistoricalLocation
+#### HistoricalLocation
 
 This entity is not mapped to any FDRI class and is unused under the FDRI to SensorThibgs mapping
 
-### Observation
+#### Observation
 
 This entity is not mapped to any FDRI class as the FDRI metadata store does not cover row-level observation metadata.
 The mapping to Observation will need to be addressed in the workstream focussed on delivering metadata+data via an API. 
 
 
-### FeatureOfInterest
+#### FeatureOfInterest
 
 This entity is only used in relation to the unmapped Observation class, however it is likely that in an implementation
 that includes Observation entities, the FeatureOfInterest entities will be derived from the reference data in the FDRI metadata store.
@@ -192,17 +192,17 @@ feature
 Observations
 : The observations for a feature of interest can be found be querying for all TimeSeriesDatasets that have the mapped GeospatialFeatureOfInterest as their feature of interest and providing access to the observations from those datasets.
 
-### ValueCode
+#### ValueCode
 
 This entity is used primarily to represent the value of classification observations in the SensorThings API model. As the FDRI mapping does not include observation data, there is no need to map ValueCode. However, in principal the obvious type mapping in the model is to `skos:Concept`.
 
-## Extension Properties
+### Extension Properties
 
 All of the entity types defined in SensorThings have a property named `properties`. The value of this property is defined as "A JSON Object containing user-annotated properties as key-value pairs.". This provides an extension point where FDRI-specific properties could be included in the SensorThings API. The requirements for these properties will depend on the particular use cases for a SensorThings API over FDRI data, in the absence of specific use cases, it is recommended that the `properties` object should contain a JSON-LD representation of the FDRI resource that is mapped to the SensorThings entity. The Location entity might be treated as a special case where only the IRI identifier and geolocation properties of the FDRI resource are included in the properties.
 
-## Implications for the FDRI model
+### Implications for the FDRI model
 
-### Introduce resource identifiers
+#### Introduce resource identifiers
 
 In the SensorThings API, each resource requires an ID property which is used to retrieve the resource from the collection that it is in. This ID property could simply be the IRI of the mapped resource but this would require escaping when used in the URIs of the SensorThings API and would make for longer, potentially less readable SensorThings API paths.
 
@@ -210,13 +210,13 @@ To address this issue, the FDRI data model could be extended to allow a property
 
 Alternatively if there are consistent templates for resource identifiers it may be possible to map FDRI resource IRIs into stub identifiers in a consistent manner that does not require any additiona property to store them.
 
-### Consider adding a Location resource type
+#### Consider adding a Location resource type
 
 Consider making a resource type equivalent to the SensorThings Location entity type. This would involve moving the properties `hasGeometry`, `hasBoundingBox` etc. which are currently defined on classes such as `EnvironmentalMonitoringFacility` and `GeospatialFeatureOfInterest` into a separate class (possibly using the GeoSPARQL `geos:Feature` class), and then having a specific relation such as `fdri:hasLocation` to relate the facility or feature of interest to its location. 
 
 **NOTE** The use of the `geo:Feature` class may be inappropriate for this purpose as its definition overlaps more strongly with the FDRI `GeospatialFeatureOfInterest` than it does with the SensorThings notion of `Location`.
 
-### Consider how to ensure a name and descrption for all entities
+#### Consider how to ensure a name and descrption for all entities
 
 In the current FDRI data model, a label is not mandatory, but in the SensorThings API the name property is mandatory for all entities. This issue may be addressed either by making an rfds:label, skos:prefLabel and/or dct:title mandatory on the relevant FDRI resource types or by defining an approach to generating labels for resources that do not have any of these properties.
 

--- a/ontology/doc/posible_changes.md
+++ b/ontology/doc/posible_changes.md
@@ -1,17 +1,19 @@
-## DONE: Remove Mobile Deployment
+## Suggested Changes to FDRI Data Model
+
+### DONE: Remove Mobile Deployment
 
 `MobileDeployment` is not really needed to capture activities involving mobile platforms. A better solution is proposed in the draft notes for UAV datasets where sensors are deployed to a mobile platform which then participates in Environmental Monitoring Activities.
 
 With this change, there may then be a case for collapsing `StaticDeployment` into `Deployment`.
 
-# DONE: Remove fdri:Agent and its subclasses
+### DONE: Remove fdri:Agent and its subclasses
 
 Rather than remove the FDRI ontology classes we opted to instead just root the FDRI Agent hierarhcy as a subclass of prov:Agent.
 
-# DONE: Remove Catchment and Region types
+### DONE: Remove Catchment and Region types
 
 These are now terms in a FacilityGroupType concept scheme
 
-# Make InternalDataProcessingConfiguration a subclass of ConfigurationValueSeries
+### Make InternalDataProcessingConfiguration a subclass of ConfigurationValueSeries
 
 An InternalDataProcessingConfiguration has hasCurrentConfiguration and hadConfiguration which are mirrored in ConfigurationValueSeries as hasCurrentValue and hadValue. Thus an  InternalDataProcessingConfiguration could be seen as a ConfigurationValueSeries where the value item is a ConfigurationItem (or a set of ConfigurationItems, although I do not believe we are currently using this).

--- a/ontology/doc/sensor-system.md
+++ b/ontology/doc/sensor-system.md
@@ -1,4 +1,4 @@
-  ## Sensor / System Model
+## Sensor / System Model
 
 This area of the model is concerned with defining sensor packages, models of sensor used and related procedures as well as the relationship to deployed instances of specific packages/sensors.
 

--- a/ontology/doc/variables.md
+++ b/ontology/doc/variables.md
@@ -1,4 +1,4 @@
-# Variables
+## Variables
 
 A `Variable` is a "description of something observed or derived, minimally consisting of an ObjectOfInterest and its Property" (taken from the description of the [I-Adopt ontology](https://i-adopt.github.io/ontology/#/Variable) upon which this part of the modelling is based).
 
@@ -20,7 +20,7 @@ Variable --> "0..n" Constraint: hasConstraint
 Constraint --> "1..n" Entity: constrains
 ```
 
-## Property
+### Property
 
 The Property facet represents the abstract characteristic of the object of interest that is measured by the Variable. Some examples:
 
@@ -30,7 +30,7 @@ The Property facet represents the abstract characteristic of the object of inter
 
 These properties should be gathered into a shared reference vocabulary and where possible it is recommended to relate properties to [QUDT QuantityKind](https://www.qudt.org/doc/DOC_VOCAB-QUANTITY-KINDS.html) instances.
 
-## ObjectOfInterest
+### ObjectOfInterest
 
 The ObjectOfInterest facet represents the class of thing whose property is measured by the Variable. e.g.
 
@@ -79,24 +79,24 @@ block-beta
 ```
 Through this reuse of vocabulary terms it is possibel to create networks of related variables and to construct more complex shared vocabularies (of variables), from more simple building blocks (properties and objects of interest).
 
-## Context
+### Context
 
 The Context facet relates a Variable to concepts which provide additional background information regarding the object of interest.
 
 > [!TODO]
 > Find an example of context from the COSMOS data
 
-## Matrix
+### Matrix
 
 Tne Matrix facet describes the thing within which the object of interest is contained. For example if a variable measures "Dissolved nitrate molar concentration in precipitation water", the object of interest is "nitrate" and the matrix is "precipitation".
 
-## Constraint
+### Constraint
 
 Constraints provide additional contextual information for the object of interest, matrix and/or context object facets. A constraint may apply to any one of these facets or to multiple facets.
 
 Constraints are often used to specify more detail about the context in which a measurement is taken e.g. "20cm depth" (which may contextualise the object of interest of a variable)
 
-# Measures
+## Measures
 
 The iAdopt framework provides a means of describing what is being observed by a dataset. However, this does not provide information about how the observations are recorded and treated in the dataset. The Measure class combines the observed property with information about the unit and statistical aggregation of the measures taken of the observed property.
 
@@ -122,10 +122,10 @@ Aggregation --> "1..1" Concept: valueStatistic
 Concept <|-- Unit
 ```
 
-## Variable
+### Variable
 The `hasVariable` property relats a Measure to the Variable for which values are provided.
 
-## Unit
+### Unit
 
 The `hasUnit` property relates a Measure to a concept that describes the units in which the measurement is expressed. Examples include:
 
@@ -138,7 +138,7 @@ Where a unit is specified, the unit name property SHOULD also be specified provi
 
 It is strongly recommended to use a common vocabulary for expressing units. The [QUDT unit vocabulary](https://www.qudt.org/doc/DOC_VOCAB-UNITS.html) provides a wide range of units as a controlled vocabulary.
 
-## Aggregation
+### Aggregation
 
 Where a measure is the result of the aggregation of multiple values over some time period, the `aggregation` property can be used to relate the Measure to an Aggregation which represents both how the input values are aggregated (using the `valueStatistic` property) to produce the recorded measurement, and the time period over which that aggregation is applied. Examples of value statistic concepts include:
 
@@ -151,7 +151,7 @@ The `periodicity` property specifies the time period between aggregate values be
 The `resolution` property specifies the time period between the measurements that are aggregated over the period.
 e.g. if `periodicity` is `PT5M` and `resolution` is `PT30S` then values are read every 30 seconds, and aggregated to produce a single aggregate value every 5 minutes.
 
-## Specialisation and Variable Hierarchies
+### Specialisation and Variable Hierarchies
 
 A Variable can have broader/narrower relations to other Variables which define more generic or more specialised variants of the Variable.
 

--- a/ontology/make_doc.py
+++ b/ontology/make_doc.py
@@ -1,0 +1,124 @@
+from pylode.profiles.ontpub import OntPub
+from bs4 import BeautifulSoup
+from dominate.tags import *
+import markdown
+import pymdownx.superfences
+import os.path
+import shutil
+import re
+
+def make_head():
+    return """
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>FDRI Metadata Ontology</title>
+        <script src="https://cdn.jsdelivr.net/npm/mermaid@11.6.0/dist/mermaid.min.js"></script>
+        <link rel="stylesheet" href="normalize.css" />
+        <link rel="stylesheet" href="styles.css" />
+        <script src="toc.js"></script>
+    </head>
+    <body>
+    <nav id="toc">
+        <h2 class="notoc">Table of Contents</h2>
+    </nav>
+    <main>
+    <h1>FDRI Metadata Ontology</h1>
+"""
+
+def fix_md_file_links(html):
+    soup = BeautifulSoup(html, 'html.parser')
+    for el in soup.find_all('a', attrs={'href': re.compile('\.md$')}):
+        el.attrs['href'] = '#' + el.attrs['href']
+    return soup.prettify()
+
+def link_fdri_entities(soup):
+    entity_map = {}
+    for entity_div in soup.find_all('div', class_='entity'):
+        entity_div_id = entity_div.attrs['id']
+        entity_map['fdri:' + entity_div_id] = '#' + entity_div_id
+
+    print(entity_map)
+    for fdri_el in soup.find_all('code', string=re.compile('^\s*fdri:')):
+        target = fdri_el.string.strip()
+        if target in entity_map:
+            fdri_el.name='a'
+            fdri_el['class']='entity'
+            fdri_el['href'] = entity_map[target]
+            fdri_el.string = target
+        # fdri_el.string = target
+        # if target in entity_map:
+        #     fdri_el.wrap(soup.new_tag('a', href=entity_map[target]))
+
+def make_section(md_path):
+    md_file = os.path.basename(md_path)
+    with open(md_path, 'r', encoding='utf-8') as input_stream:
+        text = input_stream.read()
+    html = markdown.markdown(
+        text,
+        extensions=['tables', 'pymdownx.superfences'],
+        extension_configs={
+            "pymdownx.superfences": {
+                "custom_fences": [
+                    {
+                        'name': 'mermaid',
+                        'class': 'mermaid',
+                        'format': pymdownx.superfences.fence_div_format
+                    }
+                ]
+            }
+        })
+    html = fix_md_file_links(html)
+    return f"""<section id="{md_file}">{html}</section>"""
+
+def make_reference_doc():
+    od = OntPub(ontology="owl/fdri-metadata.ttl")
+    html = od.make_html()
+    soup = BeautifulSoup(html, 'html.parser')
+    content = soup.find("div", id="content")
+    # Increment headers
+    for header in content.find_all('h4'):
+        header.name='h5'
+    for header in content.find_all('h3'):
+        header.name='h4'
+    for header in content.find_all('h2'):
+        header.name='h3'
+    for header in content.find_all('h1'):
+        header.name='h2'
+    for content_section in content.find_all('div', recursive=False):
+        content_section.unwrap()
+    content.name = 'section'
+    content.attrs['id'] = 'reference'
+    return content.prettify()
+
+def make_foot():
+    return """
+    </main>
+    </body>
+</html>
+"""
+if __name__ == '__main__':
+    html = make_head()
+    html += make_section('doc/introduction.md')
+    html += make_section('doc/programme-catalog.md')
+    html += make_section('doc/high-level-catalog-structure.md')
+    html += make_section('doc/annotations.md')
+    html += make_section('doc/time-series-dataset.md')
+    html += make_section('doc/provenance-and-activity.md')
+    html += make_section('doc/variables.md')
+    html += make_section('doc/emf.md')
+    html += make_section('doc/deployments.md')
+    html += make_section('doc/sensor-system.md')
+    html += make_section('doc/data-processing-configurations.md')
+    html += make_section('doc/geospatial.md')
+    html += make_section('doc/ogc-connected-systems.md')
+    html += make_reference_doc()
+    html += make_foot()
+    soup = BeautifulSoup(html, 'html.parser')
+    link_fdri_entities(soup)
+    with open('doc/html/index.html', 'w', encoding='utf-8') as output_stream:
+        output_stream.write(soup.prettify())
+    shutil.copyfile('doc/ogc-types.png', 'doc/html/ogc-types.png')
+    shutil.copyfile('doc/sensor-things-types.png', 'doc/html/sensor-things-types.png')
+
+


### PR DESCRIPTION
* Adds a python script to generate HTML documentation from the markdown and OWL source files.
* Markdown files are converted to HTML and merged into a single HTML file
* OWL documentation is generated using PyLODE and then merged into the HTML generated from the Markdown files
* `code` elements from the Markdown that contain a string starting `fdri:` are linked to the ontology entity when a match is found in the OWL documentation
* HTML file includes a script that generates a navigable TOC on document load (this won't work if the user has JS disabled in their browser)