### PR TITLE
Add a dct:identifier property to EMSites

### DIFF
--- a/sample_data/templates/SITES.yaml
+++ b/sample_data/templates/SITES.yaml
@@ -304,6 +304,7 @@ resources:
         "@type": <fdri:EnvironmentalMonitoringSite>
         "<rdfs:label>": "{SITE_NAME}@en"
         "<rdfs:comment>": "{SITE_DESC}@en"
+        "<dct:identifier>": "{SITE_ID}"
         "^<fdri:contains>": <::Cosmos>
         "^<fdri:utilises>": <::CosmosProgramme>
         "<geos:hasGeometry>": 


### PR DESCRIPTION
This PR addresses #181 by adding a dct:identifier property containing the site ID. For this property the original casing in the source data is also retained.

For the identifier to display, the metadata api model needs to be updated to v0.4.1. A separate PR on the dri-metadata-api repo will address that.