### PR TITLE
Reinstate the related party attribution to the operator organisation

### DIFF
--- a/sample_data/templates/NRFA_SITES.yaml
+++ b/sample_data/templates/NRFA_SITES.yaml
@@ -229,6 +229,14 @@ resources:
             "@type": "<fdri:RelatedPartyAttribution>"
             "<prov:agent>": <::OperatorAgent>
             "<dcat:hasRole>": <::OperatorRole>
+        - name: OperatorOrganisationAttribution
+          requires:
+            ORGANISATION_ID:
+          properties:
+            "@id": "<http://fdri.ceh.ac.uk/id/site/nrfa-{NRFA_ID|slug}#organisation-attribution>"
+            "@type": "<fdri:RelatedPartyAttribution>"
+            "<prov:agent>": <::OperatorOrganisationAgent>
+            "<dcat:hasRole>": <::OperatorOrganisationRole>
 
   - name: RiverGroup
     properties:


### PR DESCRIPTION
Reinstate the related party attribution to the operator organisation to make this more directly accessible via the api