### PR TITLE
Make all DEP_TS parameters dataset value references

### DIFF
--- a/sample_data/templates/CORRECTION_CONFIGS_LINES.yaml
+++ b/sample_data/templates/CORRECTION_CONFIGS_LINES.yaml
@@ -24,10 +24,17 @@ embedded:
       "@type": <fdri:ConfigurationArgument>
       "<fdri:parameter>": "<http://fdri.ceh.ac.uk/ref/common/parameter/{PARAM_ID|slug}>"
       "<fdri:hasValue>":
-        - name: StringParamValue
+        - name: TSParamValue
           requires:
             PARAM_ID:
              - DEP_TS
+          properties:
+            "@id": <http://fdri.ceh.ac.uk/id/argument/{|hash(PARAM_ID, PARAM_VALUE)|slug}#value>
+            "@type": <schema:PropertyValue>
+            "<schema:valueReference>": "<http://fdri.ceh.ac.uk/id/dataset/{PARAM_VALUE|slug}>"
+        - name: StringParamValue
+          requires:
+            PARAM_ID:
              - SITE_ATTRIBUTE
           properties:
             "@id": <http://fdri.ceh.ac.uk/id/argument/{|hash(PARAM_ID, PARAM_VALUE)|slug}#value>


### PR DESCRIPTION
This assumes that all `DEP_TS` parameter values are (after slug normalization) correct localName IDs for the TimeSeriesDataset.