### PR TITLE
Remove duplication of SKOS properties when referencing existing COP

### DIFF
--- a/sample_data/templates/ea_manual_metadata.yaml
+++ b/sample_data/templates/ea_manual_metadata.yaml
@@ -44,9 +44,6 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/common/cop/{Parameter Type|slug}>"
       "@type": "<skos:Concept>"
-      "<skos:prefLabel>": "{Parameter Type}@en"
-      "<skos:inScheme>": "<::CommonCopScheme>"
-      "^<skos:hasTopConcept>": "<::CommonCopScheme>"
 
   - name: Variable
     properties:


### PR DESCRIPTION
Fixes the rendering of the Water flow observable property in the API and eliminates the duplication of skos:prefLabel, skos:inScheme, and skos:hasTopConcept properties when making a reference to an existing COP.
Relates to comment on #203