### PR TITLE
Publish to staging-dev on pushes to main or dev branches

### DIFF
--- a/branch.map
+++ b/branch.map
@@ -1,5 +1,5 @@
 branch      sqs_queue_url                                                                                       s3_destination
 dev         https://sqs.eu-west-2.amazonaws.com/654654490827/ukceh_fdri_staging_dev_metadata_update_queue.fifo  s3://ukceh-fdri-staging-dev-metadata-state/data                                                                                                        s3://ukceh-fdri-staging-dev-metadata-state/data
-main        https://sqs.eu-west-2.amazonaws.com/654654490827/ukceh_fdri_staging_dev_metadata_update_queue.fifo  s3://ukceh-fdri-staging-dev-metadata-state/data                                                                                                        s3://ukceh-fdri-staging-dev-metadata-state/data
+main        https://sqs.eu-west-2.amazonaws.com/654654490827/ukceh_fdri_staging_dev_metadata_update_queue.fifo  s3://ukceh-fdri-staging-dev-metadata-state/data2                                                                                                        s3://ukceh-fdri-staging-dev-metadata-state/data
 staging     https://sqs.eu-west-2.amazonaws.com/654654490827/ukceh_fdri_staging_metadata_update_queue.fifo      s3://ukceh-fdri-staging-metadata-state/data
 expt        https://sqs.eu-west-1.amazonaws.com/293385631482/ceh-dev-fuseki.fifo                                s3://expt-eks-cluster/data/ceh/dev


### PR DESCRIPTION
For #215 we now need to publish the data in this repository to the staging-dev environment. This PR updates the branch map for this repo so that a push to either `main` or `dev` will result in data being published to the staging-dev environment and pushes to `staging` will result in data being published to the staging environment. 

My plan is to first merge this PR then deprecate and remove the main branch so that we just have `dev` and `staging` branches.