### PR TITLE
Add dependent dataset ids to data processing configuration

### DIFF
--- a/sample_data/sql/ts_id_dependencies.jq
+++ b/sample_data/sql/ts_id_dependencies.jq
@@ -3,5 +3,5 @@ to_entries |
 if .value then setpath(["value", "raw", .key]; .value) end |
 if .value and .value.raw then setpath(["value", "raw"]; .value.raw | tostring) end |
 if .value and .value.args then setpath(["value","args"]; .value.args|to_entries|map(if .value|type=="object" then setpath(["value"]; .value|to_entries|map({child_key: .key, value: .value})) else . end)) else . end |
-if .value and .value.depends_on then setpath(["value","depends_on"]; .value.depends_on|map({id: .})) else . end |
+if .value and .value.depends_on then setpath(["value","depends_on"]; .value.depends_on|map({dep_id: .})) else . end |
 {"id": .key} + .value

--- a/sample_data/templates/COSMOS_TS_ID_DEPENDENCIES_LINES.yaml
+++ b/sample_data/templates/COSMOS_TS_ID_DEPENDENCIES_LINES.yaml
@@ -10,7 +10,7 @@ imports:
 embedded:
   - name: Dependency
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/dataset/{id|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/dataset/{dep_id|slug}>"
 
   - name: NestedMethodArgument
     properties:
@@ -30,6 +30,18 @@ embedded:
           "<skos:inScheme>": "<::ConfigurationParameterScheme>"
           "<skos:broader>": "<http://fdri.ceh.ac.uk/ref/common/parameter/{key|slug}>"
           "^<skos:narrower>": "<http://fdri.ceh.ac.uk/ref/common/parameter/{key|slug}>"
+
+  - name: DependencyArgument
+    properties:
+      "@id": "<http://fdri.ceh.ac.uk/id/configuration-item/{id|slug}-current#dep_ts>"
+      "@type": "<fdri:ConfigurationArgument>"
+      "<fdri:parameter>": <http://fdri.ceh.ac.uk/ref/common/parameter/dep_ts>
+      "<fdri:hasValue>":
+        - name: DependencyArgumentValue
+          properties:
+            "@id": "<http://fdri.ceh.ac.uk/id/configuration-item/{id|slug}-current#dep_ts.value>"
+            "@type": "<schema:PropertyValue>"
+            "<schema:valueReference>": "<http://fdri.ceh.ac.uk/id/dataset/{dep_id|slug}>"
 
   - name: MethodArgument
     properties:
@@ -87,19 +99,29 @@ resources:
                   "<fdri:appliesToTimeSeries>": "<::Dataset>"
                   "<fdri:hasCurrentConfiguration>":
                     - name: ProcessingConfigItem
-                      requires:
-                        method:
                       properties:
                         "@id": "<http://fdri.ceh.ac.uk/id/configuration-item/{id|slug}-current>"
                         "@type": "<fdri:ConfigurationItem>"
                         "<fdri:method>":
                           - name: ProcessingMethod
+                            requires:
+                              method:
                             properties:
                               "@id": "<http://fdri.ceh.ac.uk/ref/common/method/{method|slug}>"
                               "@type": "<fdri:DataProcessingMethod>"
                               "<skos:inScheme>": "<::DataProcessingMethodScheme>"
                               "^<skos:hasTopConcept>": "<::DataProcessingMethodScheme>"
-                        "<fdri:argument>": "{args|map_to('MethodArgument')}"
+                          - name: DerivationMethod
+                            unless:
+                              method:
+                            properties:
+                              "@id": "<http://fdri.ceh.ac.uk/ref/common/method/{derivation|slug}>"
+                              "@type": "<fdri:DataProcessingMethod>"
+                              "<skos:inScheme>": "<::DataProcessingMethodScheme>"
+                              "^<skos:hasTopConcept>": "<::DataProcessingMethodScheme>"
+                        "<fdri:argument>":
+                          - "{depends_on|map_to('DependencyArgument')}"
+                          - "{args|map_to('MethodArgument')}"
                         "<fdri:interval>":
                           - name: ProcessingConfigurationItemInterval
                             properties:


### PR DESCRIPTION
Move dependent dataset list to an argument for processing configurations for parity with the QC and infill configurations. Note that this change is currently invalid against the schema and may require a schema update if adopted
