### PR TITLE
Update query to handle bad timestamp

### DIFF
--- a/sample_data/sql/rca_surveys.sql
+++ b/sample_data/sql/rca_surveys.sql
@@ -1,5 +1,7 @@
 CREATE TABLE IF NOT EXISTS metadata AS FROM './sample_data/src/rca_excel/metadata.parquet';
 UPDATE metadata SET Date = substr(Date, 0, 11);
+UPDATE metadata SET "Start Time" = lpad("Start Time", 4, '0') WHERE length("Start Time") < 4;
+UPDATE metadata SET "End Time" = lpad("End Time", 4, '0') WHERE length("End Time") < 4;
 COPY (
     SELECT
         str_split("Site Name", ' ')[1] as Site_ID, 


### PR DESCRIPTION
* Update the handling of the Start Time and End Time columns to left pad with 0 if the column contains a value less than four characters. This changes a bad time of 940 to a parseable 0940