### PR TITLE
Extend validation and address validation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ build/context/%.context.jsonld: $(SCHEMA_FILE) | build/context
 	$(RUN) record-spec-cmd json-ld -r $(*F) -o $@ $^
 
 $(SHACL_BASE)/fdri_shacl.ttl: $(SCHEMA_FILE) | $(SHACL_BASE)
-	$(RUN) record-spec-cmd shacl -o $@ $^
+	$(RUN) record-spec-cmd shacl --closed -o $@ $^
 
 $(SHACL_BASE)/fdri_shacl_with_refs.ttl: $(SCHEMA_FILE) | $(SHACL_BASE)
 	$(RUN) record-spec-cmd shacl --with-reference-type-validation -o $@ $^

--- a/sample_data/templates/ANNOTATION_PROPERTIES.yaml
+++ b/sample_data/templates/ANNOTATION_PROPERTIES.yaml
@@ -12,7 +12,7 @@ one_offs:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/common/annotation-property>"
       "@type": <fdri:VariableScheme>
-      "<skos:prefLabel>": "Annotation Property Scheme@en"
+      "<dct:title>": "Annotation Property Scheme@en"
       "<rdfs:label>": "Annotation Property Scheme@en"
 
 resources:
@@ -59,7 +59,7 @@ resources:
       "<fdri:valueScheme>": "<{VALUE_SCHEME_URI}>"
       "<skos:prefLabel>": "{NAME}@en"
       "<rdfs:label>": "{NAME}@en"
-      "<dct:description>": "{DESCRIPTION}@en"
+      "<rdfs:comment>": "{DESCRIPTION}@en"
       "<skos:scopeNote>": "{DESCRIPTION}@en"
 
   - name: AnnotationPropertyConcept
@@ -70,7 +70,7 @@ resources:
       "@type": <skos:Concept>
       "<skos:prefLabel>": "{NAME}@en"
       "<rdfs:label>": "{NAME}@en"
-      "<dct:description>": "{DESCRIPTION}@en"
+      "<rdfs:comment>": "{DESCRIPTION}@en"
       "<skos:scopeNote>": "{DESCRIPTION}@en"
 
   - name: ParentRef

--- a/sample_data/templates/NRFA_SITES.yaml
+++ b/sample_data/templates/NRFA_SITES.yaml
@@ -25,12 +25,14 @@ one_offs:
       "@id": <http://fdri.ceh.ac.uk/ref/nrfa/group-type>
       "@type": <fdri:FacilityGroupTypeScheme>
       "<dct:title>": "NRFA Monitoring Facility Group Types@en"
+      "<rdfs:label>": "NRFA Monitoring Facility Group Types@en"
 
   - name: RiverGroupType
     properties:
       "@id": <http://fdri.ceh.ac.uk/ref/nrfa/group-type/river>
       "@type": <fdri:FacilityGroupType>
-      "<dct:title>": "NRFA River Group@en"
+      "<rdfs:label>": "NRFA River Group@en"
+      "<skos:prefLabel>": "NRFA River Group@en"
       "<skos:inScheme>": <::NrfaFacilityGroupTypeScheme>
       "^<skos:hasTopConcept>": <::NrfaFacilityGroupTypeScheme>
 
@@ -38,7 +40,8 @@ one_offs:
     properties:
       "@id": <http://fdri.ceh.ac.uk/ref/nrfa/group-type/location>
       "@type": <fdri:FacilityGroupType>
-      "<dct:title>": "NRFA Location Group@en"
+      "<rdfs:label>": "NRFA Location Group@en"
+      "<skos:prefLabel>": "NRFA Location Group@en"
       "<skos:inScheme>": <::NrfaFacilityGroupTypeScheme>
       "^<skos:hasTopConcept>": <::NrfaFacilityGroupTypeScheme>
 
@@ -46,7 +49,8 @@ one_offs:
     properties:
       "@id": <http://fdri.ceh.ac.uk/ref/nrfa/group-type/country>
       "@type": <fdri:FacilityGroupType>
-      "<dct:title>": "NRFA Country Group@en"
+      "<rdfs:label>": "NRFA Country Group@en"
+      "<skos:prefLabel>": "NRFA Country Group@en"
       "<skos:inScheme>": <::NrfaFacilityGroupTypeScheme>
       "^<skos:hasTopConcept>": <::NrfaFacilityGroupTypeScheme>
 
@@ -54,8 +58,10 @@ one_offs:
     properties:
       "@id": <http://fdri.ceh.ac.uk/ref/common/related-party-role/operator>
       "@type": <fdri:RelatedPartyRole>
-      "<dct:title>": "Operator@en"
-      "<dct:description>": "The organisation or person that operates the monitoring site@en"
+      "<skos:prefLabel>": "Operator@en"
+      "<skos:scopeNote>": "The organisation or person that operates the monitoring site@en"
+      "<rdfs:label>": "Operator@en"
+      "<rdfs:comment>": "The organisation or person that operates the monitoring site@en"
       "<skos:inScheme>": <::CommonRelatedPartyRoleScheme>
       "^<skos:hasTopConcept>": <::CommonRelatedPartyRoleScheme>
 
@@ -63,8 +69,10 @@ one_offs:
     properties:
       "@id": <http://fdri.ceh.ac.uk/ref/common/related-party-role/operator-organisation>
       "@type": <fdri:RelatedPartyRole>
-      "<dct:title>": "Operator Organisation@en"
-      "<dct:description>": "The parent organisation of the organisation or person that operates the monitoring site@en"
+      "<rdfs:label>": "Operator Organisation@en"
+      "<skos:prefLabel>": "Operator Organisation@en"
+      "<rdfs:comment>": "The parent organisation of the organisation or person that operates the monitoring site@en"
+      "<skos:scopeNote>": "The parent organisation of the organisation or person that operates the monitoring site@en"
       "<skos:inScheme>": <::CommonRelatedPartyRoleScheme>
       "^<skos:hasTopConcept>": <::CommonRelatedPartyRoleScheme>
 
@@ -185,7 +193,7 @@ resources:
     properties:
       "@id": <http://fdri.ceh.ac.uk/id/facility-group/nrfa-river-{RIVER|slug}>
       "@type": <fdri:FacilityGroup>
-      "<dct:title>": "{RIVER}@en"
+      "<rdfs:label>": "{RIVER}@en"
       "<dct:type>": <::RiverGroupType>
       "<fdri:hasMember>": <::MonitoringSite>
 
@@ -193,7 +201,7 @@ resources:
     properties:
       "@id": <http://fdri.ceh.ac.uk/id/facility-group/nrfa-location-{LOCATION|slug}>
       "@type": <fdri:FacilityGroup>
-      "<dct:title>": "{LOCATION}@en"
+      "<rdfs:label>": "{LOCATION}@en"
       "<dct:type>": <::LocationGroupType>
       "<fdri:hasMember>": <::MonitoringSite>
 
@@ -203,7 +211,7 @@ resources:
     properties:
       "@id": <http://fdri.ceh.ac.uk/id/facility-group/nrfa-country-{COUNTRY_CODE|slug}>
       "@type": <fdri:FacilityGroup>
-      "<dct:title>": "{COUNTRY_CODE}@en"
+      "<rdfs:label>": "{COUNTRY_CODE}@en"
       "<dct:type>": <::CountryGroupType>
       "<fdri:hasMember>": <::MonitoringSite>
 

--- a/sample_data/templates/SITES.yaml
+++ b/sample_data/templates/SITES.yaml
@@ -17,7 +17,7 @@ one_offs:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/group-type/region>"
       "@type": "<fdri:FacilityGroupType>"
-      "<dct:title>": "COSMOS Region Group@en"
+      "<skos:prefLabel>": "COSMOS Region Group@en"
       "<skos:inScheme>": <::CosmosFacilityGroupTypeScheme>
       "^<skos:hasTopConcept>": <::CosmosFacilityGroupTypeScheme>
   - name: SoilTypeScheme
@@ -75,7 +75,7 @@ resources:
       properties:
         "@id": "<http://fdri.ceh.ac.uk/id/facility-group/cosmos-region-{REGION|slug}>"
         "@type": <fdri:FacilityGroup>
-        "<dct:title>": "{REGION} Region Group"
+        "<rdfs:label>": "{REGION} Region Group"
         "<dct:type>": <::RegionGroupType>
     
     - name: MonitoringSite

--- a/sample_data/templates/fdri_sites.yaml
+++ b/sample_data/templates/fdri_sites.yaml
@@ -56,7 +56,6 @@ resources:
       "@type": "<fdri:EnvironmentalMonitoringPlatform>"
       "<rdfs:label>": "{Platform}@en"
       "<dct:identifier>": "{Site}-{Platform}"
-      "^<sosa:hosts>": "<::Site>"
       "^<dct:hasPart>": <::Site>
 
 

--- a/sample_data/templates/flowstick_surveys.yaml
+++ b/sample_data/templates/flowstick_surveys.yaml
@@ -33,9 +33,6 @@ resources:
       "<fdri:measures>":
         - <http://fdri.ceh.ac.uk/ref/common/measure/water_velocity-inst-ms-1>
         - <http://fdri.ceh.ac.uk/ref/common/measure/water_temp-inst-degc>
-      "<sosa:observes>":
-        - <http://fdri.ceh.ac.uk/ref/common/cop/water_velocity>
-        - <http://fdri.ceh.ac.uk/ref/common/cop/water_temp>
 
   - name: SensorFirmwareConfiguration
     properties:
@@ -70,7 +67,6 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/activity/flowstick-{Site_Name|slug}-{Date|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringActivity>"
       "<dct:type>": <::FlowstickSurveyType>
-      "<dct:title>": "Flowstick survey at {Site_Name} on {Date}@en"
       "<rdfs:label>": "Flowstick survey at {Site_Name} on {Date}@en"
       "<sosa:hasFeatureOfInterest>": "<::FeatureOfInterest>"
       "<fdri:facilityUsage>":

--- a/sample_data/templates/gridded_metadata.yaml
+++ b/sample_data/templates/gridded_metadata.yaml
@@ -127,7 +127,7 @@ resources:
         - "{description}@en"
         - "{source}@en"
       "<dcat:temporalResolution>": "{temporal_resolution}^^<xsd:duration>"
-      "<dct:keyword>": "{keywords|split(',')|trim()}"
+      "<dcat:keyword>": "{keywords|split(',')|trim()}"
       "<dct:created>": "{date_created|asDateTime}"
       "<dct:license>": "<{license}>"
       "<dct:identifier>": "{id}"

--- a/sample_data/templates/rca_surveys.yaml
+++ b/sample_data/templates/rca_surveys.yaml
@@ -131,11 +131,11 @@ resources:
       "<fdri:originatingActivity>": "<::Survey>"
       "<fdri:originatingSite>": "<::Site>"
       "<sosa:hasFeatureOfInterest>": "<::FeatureOfInterest>"
-      "<sosa:observes>":
-        - <http://fdri.ceh.ac.uk/ref/common/cop/rev_count>
+      "<sosa:observedProperty>":
+        - <http://fdri.ceh.ac.uk/ref/common/cop/rev>
         - <http://fdri.ceh.ac.uk/ref/common/cop/water_velocity>
         - <http://fdri.ceh.ac.uk/ref/common/cop/discharge>
-      "<fdri:measures>":
+      "<fdri:measure>":
         - <http://fdri.ceh.ac.uk/ref/common/measure/rev-total-count>
         - <http://fdri.ceh.ac.uk/ref/common/measure/angular_velocity-revs-1>
         - <http://fdri.ceh.ac.uk/ref/common/measure/water_velocity-inst-ms-1>

--- a/sample_data/templates/sensor_calibrations.yaml
+++ b/sample_data/templates/sensor_calibrations.yaml
@@ -15,7 +15,7 @@ one_offs:
       "<rdfs:label>": "Correction Factor@en"
       "<skos:prefLabel>": "Correction Factor@en"
       "<skos:inScheme>": "<::ConfigurationParameterScheme>"
-      "^<skos:inScheme>": "<::ConfigurationParameterScheme>"
+      "^<skos:hasTopConcept>": "<::ConfigurationParameterScheme>"
 
   - name: SensorCalibrationConfiguration
     properties:
@@ -32,7 +32,7 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
-      "<dct:title>": "{INSTRUMENT_ID} {SERIAL_NUMBER}@en"
+      "<rdfs:label>": "{INSTRUMENT_ID} {SERIAL_NUMBER}@en"
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
       "<fdri:serialNumber>": "{SERIAL_NUMBER}"
 
@@ -50,9 +50,14 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/activity/calibration-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{START_TIMESTAMP|slug}>"
       "@type": "<prov:Activity>"
-      "<prov:used>": <::Sensor>
-      "<prov:startedAt>": "{START_TIMESTAMP}^^<xsd:dateTime>"
-      "<prov:endedAt>": "{END_TIMESTAMP}^^<xsd:dateTime>"
+      "<prov:qualifiedUsage>":
+        - name: CalibrationActivityUsage
+          properties:
+            "@id": "<http://fdri.ceh.ac.uk/id/activity/calibration-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{START_TIMESTAMP|slug}#usage>"
+            "@type": "<prov:Usage>"
+            "<prov:entity>": <::Sensor>
+      "<prov:startedAtTime>": "{START_TIMESTAMP}^^<xsd:dateTime>"
+      "<prov:endedAtTime>": "{END_TIMESTAMP}^^<xsd:dateTime>"
 
   - name: CalibrationConfiguration
     properties:
@@ -70,6 +75,7 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/configuration-item/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{TIMESERIES_ID|slug}-{START_TIMESTAMP|slug}>"
       "@type": "<fdri:ConfigurationItem>"
       "^<fdri:hadValue>": <::CalibrationConfiguration>
+      "<fdri:method>": <::CorrectionMethod>
       "<prov:wasGeneratedBy>": <::CalibrationActivity>
       "<fdri:observationInterval>":
         - name: CalibrationConfigurationInterval
@@ -83,7 +89,6 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/configuration-argument/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{TIMESERIES_ID|slug}-{START_TIMESTAMP|slug}>"
       "@type": "<fdri:ConfigurationArgument>"
-      "<fdri:method>": <::CorrectionMethod>
       "<fdri:parameter>": "<::CorrectionFactorParameter>"
       "<fdri:hasValue>":
         - name: CalibrationConfigurationItemValue

--- a/sample_data/templates/sensor_deployments.yaml
+++ b/sample_data/templates/sensor_deployments.yaml
@@ -20,7 +20,7 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
-      "<dct:title>": "{INSTRUMENT_ID} {SERIAL_NUMBER}@en"
+      "<rdfs:label>": "{INSTRUMENT_ID} {SERIAL_NUMBER}@en"
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
       "<fdri:serialNumber>": "{SERIAL_NUMBER}"
 
@@ -31,7 +31,7 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/deployment/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{INSTANCE|asInt}>"
       "@type": "<fdri:StaticDeployment>"
-      "<dct:title>": "Deployment of {INSTRUMENT_ID} {SERIAL_NUMBER} to {SENSOR_SLOT_ID} at {SITE_ID}@en"
+      "<rdfs:label>": "Deployment of {INSTRUMENT_ID} {SERIAL_NUMBER} to {SENSOR_SLOT_ID} at {SITE_ID}@en"
       "<ssn:deployedSystem>": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
       "<ssn:deployedOnPlatform>": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}>"
       "<prov:startedAtTime>": "{START_DATETIME|asDateTime}"
@@ -44,7 +44,6 @@ resources:
       END_DATETIME:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/deployment/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{INSTANCE|asInt}>"
-      "@type": "<fdri:Deployment>"
       "<prov:endedAtTime>": "{END_DATETIME|asDateTime}"
 
   - name: SensorDeploymentComments
@@ -54,5 +53,4 @@ resources:
       COMMENTS:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/deployment/cosmos-deployment-{SITE_ID|slug}-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{INSTANCE|asInt}>"
-      "@type": "<fdri:Deployment>"
-      "<dct:description>": "{COMMENTS}@en"
+      "<rdfs:comment>": "{COMMENTS}@en"

--- a/sample_data/templates/sensor_faults.yaml
+++ b/sample_data/templates/sensor_faults.yaml
@@ -14,7 +14,7 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/fault/cosmos-{$row}>"
       "@type": "<fdri:Fault>"
-      "<dct:description>": "{DESCRIPTION_OF_ISSUE}@en"
+      "<rdfs:comment>": "{DESCRIPTION_OF_ISSUE}@en"
       "<fdri:removeData>": "{REMOVE_DATA|asBoolean('y')}"
       "<fdri:affectedVariable>": "<http://fdri.ceh.ac.uk/ref/common/cop/{VARIABLE|slug}>"
       "<fdri:interval>":
@@ -25,6 +25,7 @@ resources:
           "<dcat:startDate>": "{START_DATETIME|asDateTime}"
           "<dcat:endDate>": "{END_DATETIME|asDateTime}"
       "<fdri:affectedFacility>": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
+
   - name: StationFault
     requires:
       VARIABLE:
@@ -32,7 +33,7 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/fault/cosmos-{$row}>"
       "@type": "<fdri:Fault>"
-      "<dct:description>": "{DESCRIPTION_OF_ISSUE}@en"
+      "<rdfs:comment>": "{DESCRIPTION_OF_ISSUE}@en"
       "<fdri:removeData>": "{REMOVE_DATA|asBoolean('y')}"
       "<fdri:affectedVariable>": "<http://fdri.ceh.ac.uk/ref/common/cop/{VARIABLE|slug}>"
       "<fdri:interval>":

--- a/sample_data/templates/sontek_surveys.yaml
+++ b/sample_data/templates/sontek_surveys.yaml
@@ -26,14 +26,12 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/site/rca-{Site_Number|slug}>"
       "@type": <fdri:EnvironmentalMonitoringSite>
       "<rdfs:label>": "{Site_Number}: {Site_Name}@en"
-      "<dct:title>": "{Site_Number}: {Site_Name}@en"
 
   - name: FeatureOfInterest
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/feature/rca-{Site_Number|slug}>"
       "@type": "<fdri:GeospatialFeatureOfInterest>"
       "<rdfs:label>": "Environment at {Site_Name}@en"
-      "<dct:title>": "Environment at {Site_Name}@en"
 
   - name: SurveyInterval
     properties:
@@ -62,7 +60,7 @@ resources:
       "@type": "<fdri:EnvironmentalMonitoringSystem>"
       "<rdfs:label>": "Sontek Handheld Device {Handheld_Serial_Number}@en"
       "<dct:type>": <::SontekHandheldDeviceType>
-      "<fdri:hasSerialNumber>": "{Handheld_Serial_Number}@en"
+      "<fdri:serialNumber>": "{Handheld_Serial_Number}"
       "<fdri:configuration>":
         - <::HandheldDeviceConfiguration>
 
@@ -100,7 +98,7 @@ resources:
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
       "<rdfs:label>": "Sontek ADV Device {ADV_Serial_Number}@en"
       "<dct:type>": <::SontekADVDeviceType>
-      "<fdri:hasSerialNumber>": "{ADV_Serial_Number}@en"
+      "<fdri:serialNumber>": "{ADV_Serial_Number}"
       "<fdri:configuration>":
         - <::ADVConfiguration>
         - <::ADVBeamsConfiguration>
@@ -110,7 +108,6 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/activity/sontek-survey-{Survey_ID|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringActivity>"
       "<dct:type>": <::SontekSurveyType>
-      "<dct:title>": "Sontek survey at {Site_Name} starting {Start_Time}@en"
       "<rdfs:label>": "Sontek survey at {Site_Name} starting {Start_Time}@en"
       "<sosa:hasFeatureOfInterest>": <::FeatureOfInterest>
       "<prov:startedAtTime>": "{Start_Time}^^<xsd:dateTime>"


### PR DESCRIPTION
* Update the per-file validation to use closed SHACL shapes for validation. This flags up unexpected properties as validation errors
* Update templates to address the validation errors encountered

NOTE: The "full" validation that checks references cannot currently use the closed SHACL shapes because reference shape validation doesn't currently take into account the polymorphism of property ranges. Some extension to the generated SHACL is needed to address this. However the individual file validation is good enough to catch unexpected properties.