### PR TITLE
Test to see if max is a required parameter

### DIFF
--- a/sample_data/src/CORRECTION_CONFIGS.json
+++ b/sample_data/src/CORRECTION_CONFIGS.json
@@ -3029,6 +3029,10 @@
             {
                 "PARAM_ID": "MIN",
                 "PARAM_VALUE": 0
+            },
+            {
+                "PARAM_ID": "MAX",
+                "PARAM_VALUE": null
             }
         ]
     },
@@ -3041,6 +3045,10 @@
         "parameters": [
             {
                 "PARAM_ID": "MIN",
+                "PARAM_VALUE": 0
+            },
+            {
+                "PARAM_ID": "MAX",
                 "PARAM_VALUE": 0
             }
         ]


### PR DESCRIPTION
The arguments for the CLIP correction method aren't showing on the data processing configuration end point: https://dri-metadata-api-dev.staging.eds.ceh.ac.uk/id/data-processing-configuration/lcil0i9proidc45tl3hkqj5maa2src1k

Wondering whether the way we've specified the CLIP parameters means that MAX also has to be provided.  