### PR TITLE
Remove explicit datatype from value mapping.

### DIFF
--- a/sample_data/templates/CORRECTION_CONFIGS_LINES.yaml
+++ b/sample_data/templates/CORRECTION_CONFIGS_LINES.yaml
@@ -46,7 +46,7 @@ embedded:
               - SITE_ATTRIBUTE
           properties:
             "@id": <http://fdri.ceh.ac.uk/id/argument/{|hash(PARAM_ID, PARAM_VALUE)|slug}#value>
-            "<schema:value>": "{PARAM_VALUE|asDecimal}^^<xsd:decimal>"
+            "<schema:value>": "{PARAM_VALUE|asDecimal}"
 
 resources:
   - name: Configuration


### PR DESCRIPTION
 All values will be xsd:decimal in any case due to the value filter