### PR TITLE
Ensure an EMPlatform is created for deployment slots at a site

### DIFF
--- a/sample_data/templates/sensor_deployments.yaml
+++ b/sample_data/templates/sensor_deployments.yaml
@@ -24,6 +24,15 @@ resources:
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
       "<fdri:serialNumber>": "{SERIAL_NUMBER}"
 
+  - name: SensorSlot
+    requires:
+      SENSOR_SLOT_ID:
+    properties:
+      "@id": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}>"
+      "@type": "<fdri:EnvironmentalMonitoringPlatform>"
+      "<rdfs:label>": "Sensor slot {SENSOR_SLOT_ID} at {SITE_ID}@en"
+      "^<dct:hasPart>": "<http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}>"
+
   - name: SensorDeployment
     requires:
       INSTRUMENT_ID:
@@ -32,8 +41,8 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/deployment/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{INSTANCE|asInt}>"
       "@type": "<fdri:StaticDeployment>"
       "<rdfs:label>": "Deployment of {INSTRUMENT_ID} {SERIAL_NUMBER} to {SENSOR_SLOT_ID} at {SITE_ID}@en"
-      "<ssn:deployedSystem>": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
-      "<ssn:deployedOnPlatform>": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}>"
+      "<ssn:deployedSystem>": "<::Sensor>"
+      "<ssn:deployedOnPlatform>": "<::SensorSlot>"
       "<prov:startedAtTime>": "{START_DATETIME|asDateTime}"
       "<fdri:deployedHeight>": "{INSTALLATION_HEIGHT|asDecimal}"
 


### PR DESCRIPTION
Added to cover the case of a deployment of a phenocam lens. In this case the site already had a definition for the phenocam slot, but not for the lens1 and lens2 slots. This PR ensures that if there is a deployment to a slot, we create the slot as an EMPlatform that is part of the parent site.