### PR TITLE
Add validation check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ contexts: $(CONTEXTS)
 samples: $(SAMPLES)
 reports: $(REPORTS)
 full_validation: $(VAL)/full_report.ttl
+	grep -q -E "conforms\s+true" $^
 
 validate: $(SCHEMA_FILE)
 	$(RUN) record-spec-cmd validate $^


### PR DESCRIPTION
Make full_validation target fail if there are conformance errors reported.
All of the outputs will be generated, but the target now includes a grep command to check for `conforms true` in the full validation output file. If that is not found, the make process will exit with an error code that can be used to fail the build in CI