### PR TITLE
Replace appliesToTimeSeries with appliesToDataset

### DIFF
--- a/sample_data/templates/CORRECTION_CONFIGS_LINES.yaml
+++ b/sample_data/templates/CORRECTION_CONFIGS_LINES.yaml
@@ -54,7 +54,7 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/data-processing-configuration/{|hash(CORRECT_TS, METHOD_ID, OBS_START_DATETIME)|slug}>"
       "@type": <fdri:InternalDataProcessingConfiguration>
       "<dct:type>": <http://fdri.ceh.ac.uk/ref/common/configuration-type/correction-configuration>
-      "<fdri:appliesToTimeSeries>": "<http://fdri.ceh.ac.uk/id/dataset/{CORRECT_TS|slug}>"
+      "<fdri:appliesToDataset>": "<http://fdri.ceh.ac.uk/id/dataset/{CORRECT_TS|slug}>"
       "<dct:title>": "Correction Configuration for {CORRECT_TS}@en"
 
   - name: ConfigurationItem

--- a/sample_data/templates/CORRECTION_FACTORS.yaml
+++ b/sample_data/templates/CORRECTION_FACTORS.yaml
@@ -26,7 +26,7 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/data-processing-configuration/cosmos-correction-{TIMESERIES_ID|slug}>"
       "@type": "<fdri:InternalDataProcessingConfiguration>"
-      "<fdri:appliesToTimeSeries>": <http://fdri.ceh.ac.uk/id/dataset/{TIMESERIES_ID|slug}>
+      "<fdri:appliesToDataset>": <http://fdri.ceh.ac.uk/id/dataset/{TIMESERIES_ID|slug}>
       "<dct:type>": <::Correction>
 
   - name: ConfigurationItem

--- a/sample_data/templates/COSMOS_TS_ID_DEPENDENCIES_LINES.yaml
+++ b/sample_data/templates/COSMOS_TS_ID_DEPENDENCIES_LINES.yaml
@@ -106,7 +106,7 @@ resources:
                         "@type": "<fdri:DataProcessingConfigurationType>"
                         "<skos:inScheme>": "<::ConfigurationTypeScheme>"
                         "^<skos:hasTopConcept>": "<::ConfigurationTypeScheme>"
-                  "<fdri:appliesToTimeSeries>": "<::Dataset>"
+                  "<fdri:appliesToDataset>": "<::Dataset>"
                   "<fdri:hasCurrentValue>":
                     - name: ProcessingConfigItem
                       properties:

--- a/sample_data/templates/QC_CONFIGS.yaml
+++ b/sample_data/templates/QC_CONFIGS.yaml
@@ -28,7 +28,7 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/data-processing-configuration/{FLAG_TS|slug}-{METHOD_ID|slug}>"
       "@type": <fdri:InternalDataProcessingConfiguration>
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/common/configuration-type/qc>"
-      "<fdri:appliesToTimeSeries>": <::FlagTS>
+      "<fdri:appliesToDataset>": <::FlagTS>
 
   - name: CurrentConfigurationItem
     properties:

--- a/sample_data/templates/alt_data_config.yaml
+++ b/sample_data/templates/alt_data_config.yaml
@@ -61,7 +61,7 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/data-processing-configuration/cosmos-infill-{TIMESERIES_ID|slug}>"
       "@type": "<fdri:InternalDataProcessingConfiguration>"
       "<dct:type>": <::InfillConfiguration>
-      "<fdri:appliesToTimeSeries>": <http://fdri.ceh.ac.uk/id/dataset/{TIMESERIES_ID|slug}>
+      "<fdri:appliesToDataset>": <http://fdri.ceh.ac.uk/id/dataset/{TIMESERIES_ID|slug}>
 
   - name: PriorityAnnotation
     properties:

--- a/sample_data/templates/concept_schemes.yaml
+++ b/sample_data/templates/concept_schemes.yaml
@@ -2,7 +2,7 @@ one_offs:
   - name: AggregationScheme
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/common/aggregation>"
-      "@type": "<skos:ConceptScheme>"
+      "@type": "<fdri:AggregationScheme>"
       "<dct:title>": "FDRI Common Value Aggregations@en"
       "<rdfs:label>": "FDRI Common Value Aggregations@en"
 
@@ -37,14 +37,14 @@ one_offs:
   - name: ContextObjectScheme
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/common/context>"
-      "@type": "<skos:ConceptScheme>"
+      "@type": "<fdri:EntityScheme>"
       "<dct:title>": "FDRI Common context objects@en"
       "<rdfs:label>": "FDRI Common context objects@en"
 
   - name: DataProcessingMethodScheme
     properties:
       "@id": <http://fdri.ceh.ac.uk/ref/common/method>
-      "@type": <skos:ConceptScheme>
+      "@type": "<fdri:DataProcessingMethodScheme>"
       "<dct:title>": "Data Processing Methods@en"
       "<rdfs:label>": "Data Processing Methods@en"
   
@@ -58,7 +58,7 @@ one_offs:
   - name: ObjectOfInterestScheme
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/common/object-of-interest>"
-      "@type": "<skos:ConceptScheme>"
+      "@type": "<fdri:EntityScheme>"
       "<dct:title>": "FDRI Common Objects Of Interest@en"
       "<rdfs:label>": "FDRI Common Objects Of Interest@en"
 
@@ -72,7 +72,7 @@ one_offs:
   - name: PropertyScheme
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/common/property>"
-      "@type": "<skos:ConceptScheme>"
+      "@type": "<fdri:PropertyScheme>"
       "<dct:title>": "FDRI Common Properties@en"
       "<rdfs:label>": "FDRI Common Properties@en"
 

--- a/sample_data/templates/infill_config.yaml
+++ b/sample_data/templates/infill_config.yaml
@@ -30,7 +30,7 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/data-processing-configuration/cosmos-infill-{TIMESERIES_ID|slug}>"
       "@type": "<fdri:InternalDataProcessingConfiguration>"
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/common/configuration-type/infill-configuration>"
-      "<fdri:appliesToTimeSeries>": <http://fdri.ceh.ac.uk/id/dataset/{TIMESERIES_ID|slug}>
+      "<fdri:appliesToDataset>": <http://fdri.ceh.ac.uk/id/dataset/{TIMESERIES_ID|slug}>
   
   - name: PriorityAnnotation
     properties:

--- a/sample_data/templates/phenocam_mask_config.yaml
+++ b/sample_data/templates/phenocam_mask_config.yaml
@@ -43,7 +43,7 @@ resources:
       "@type": "<fdri:InternalDataProcessingConfiguration>"
       "<dct:type>": <::PhenocamMaskConfigurationType>
       "<fdri:appliesToFacility>": <http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}>
-      "<fdri:appliesToTimeSeries>":
+      "<fdri:appliesToDataset>":
         - <http://fdri.ceh.ac.uk/ref/cosmos/time-series/image_red_{FEATURE_ID|slug}>
         - <http://fdri.ceh.ac.uk/ref/cosmos/time-series/image_green_{FEATURE_ID|slug}>
         - <http://fdri.ceh.ac.uk/ref/cosmos/time-series/image_blue_{FEATURE_ID|slug}>

--- a/sample_data/templates/sensor_calibrations.yaml
+++ b/sample_data/templates/sensor_calibrations.yaml
@@ -64,7 +64,7 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/data-processing-configuration/cosmos-calibration-configuration-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{TIMESERIES_ID|slug}>"
       "@type": "<fdri:InternalDataProcessingConfiguration>"
       "<fdri:appliesToFacility>": <::Sensor>
-      "<fdri:appliesToTimeSeries>": "<http://fdri.ceh.ac.uk/id/dataset/{TIMESERIES_ID|slug}>"
+      "<fdri:appliesToDataset>": "<http://fdri.ceh.ac.uk/id/dataset/{TIMESERIES_ID|slug}>"
       "<dct:type>": <::SensorCalibrationConfiguration>
 
   

--- a/sample_data/templates/tsdef_dependencies.yaml
+++ b/sample_data/templates/tsdef_dependencies.yaml
@@ -86,7 +86,7 @@ resources:
                         "@type": "<fdri:DataProcessingConfigurationType>"
                         "<skos:inScheme>": "<::ConfigurationTypeScheme>"
                         "^<skos:hasTopConcept>": "<::ConfigurationTypeScheme>"
-                  "<fdri:appliesToTimeSeries>": <::Dataset>
+                  "<fdri:appliesToDataset>": <::Dataset>
                   "<fdri:hasCurrentValue>": 
                     - name: ProcessingConfigItem
                       requires:


### PR DESCRIPTION
As discussed on NERC-CEH/fdri-ontology#77
This PR replaces the fdri:appliesToTimeSeries property with fdri:appliesToDataset.
The PR also updates the ontology to the latest version and updates some concept scheme types to ensure validation against the latest version of the schema.