### PR TITLE
Map sensor slot name annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ SAMPLES += $(TTL_BASE)/sensor_deployments.ttl
 SAMPLES += $(TTL_BASE)/sensor_faults.ttl
 SAMPLES += $(TTL_BASE)/sensor_firmware_configurations.ttl
 SAMPLES += $(TTL_BASE)/SITE_CALIBRATION_INFO.ttl
+SAMPLES += $(TTL_BASE)/site_slots.ttl
 SAMPLES += $(TTL_BASE)/SITES.ttl
 SAMPLES += $(TTL_BASE)/siteVariance.ttl
 SAMPLES += $(TTL_BASE)/STATISTICS.ttl
@@ -193,6 +194,9 @@ build/phenocam_mask_config.csv: $(SRC)/PHENOCAM_MASKS.csv $(SQL)/phenocam_mask_c
 
 build/sensor_deployments.csv: $(SRC)/SITE_INSTRUMENTATION.csv $(SRC)/TIMESERIES_IDS_COSMOS.csv $(SRC)/MEASURES.csv $(SQL)/sensor_deployments.sql | build
 	$(RUN) /bin/bash -c "duckdb < $(SQL)/sensor_deployments.sql"
+
+build/site_slots.csv: $(SRC)/SITE_INSTRUMENTATION.csv $(SRC)/SENSOR_SLOT_IDS.csv $(SQL)/site_slots.sql | build
+	$(RUN) /bin/bash -c "duckdb < $(SQL)/site_slots.sql"
 
 build/sensor_faults.csv: $(SRC)/SENSOR_FAULTS.csv $(SRC)/TIMESERIES_IDS_COSMOS.csv $(SRC)/SITE_INSTRUMENTATION.csv $(SQL)/sensor_faults.sql | build
 	$(RUN) /bin/bash -c "duckdb < $(SQL)/sensor_faults.sql"

--- a/sample_data/sql/site_slots.sql
+++ b/sample_data/sql/site_slots.sql
@@ -1,0 +1,12 @@
+create table SI as from read_csv('./sample_data/src/SITE_INSTRUMENTATION.csv', AUTO_DETECT=true);
+create table SS as from read_csv('./sample_data/src/SENSOR_SLOT_IDS.csv', AUTO_DETECT=true);
+create table SITES as from read_csv('./sample_data/src/SITES.csv', AUTO_DETECT=true);
+
+COPY(
+    SELECT DISTINCT SI.SITE_ID, SI.SENSOR_SLOT_ID,SS.SENSOR_SLOT_NAME,SITES.SITE_NAME
+    FROM SI
+    LEFT JOIN SS
+    ON SI.SENSOR_SLOT_ID = SS.SENSOR_SLOT_ID
+    LEFT JOIN SITES
+    ON SI.SITE_ID = SITES.SITE_ID
+) TO './build/site_slots.csv' WITH (HEADER, DELIMITER ',');

--- a/sample_data/templates/sensor_deployments.yaml
+++ b/sample_data/templates/sensor_deployments.yaml
@@ -24,31 +24,6 @@ resources:
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
       "<fdri:serialNumber>": "{SERIAL_NUMBER}"
 
-  - name: SensorSlotNameAnnotation
-    requires:
-      SENSOR_SLOT_ID:
-      SENSOR_SLOT_NAME:
-    properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}#sensor-slot-name>"
-      "@type": <fdri:Annotation>
-      "<fdri:property>": "<http://fdri.ceh.ac.uk/ref/common/annotation-property/sensor-slot-name>"
-      "<fdri:hasValue>":
-        - name: SensorSlotName
-          properties:
-            "@id": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}#sensor-slot-name.value>"
-            "@type": <schema:PropertyValue>
-            "<schema:value>": "{SENSOR_SLOT_NAME}"
-
-  - name: SensorSlot
-    requires:
-      SENSOR_SLOT_ID:
-    properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}>"
-      "@type": "<fdri:EnvironmentalMonitoringPlatform>"
-      "<rdfs:label>": "{SENSOR_SLOT_NAME} at {SITE_ID}@en"
-      "<fdri:hasAnnotation>": "<::SensorSlotNameAnnotation>"
-      "^<dct:hasPart>": "<http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}>"
-
   - name: SensorDeployment
     requires:
       INSTRUMENT_ID:
@@ -58,7 +33,7 @@ resources:
       "@type": "<fdri:StaticDeployment>"
       "<rdfs:label>": "Deployment of {INSTRUMENT_ID} {SERIAL_NUMBER} to {SENSOR_SLOT_ID} at {SITE_ID}@en"
       "<ssn:deployedSystem>": "<::Sensor>"
-      "<ssn:deployedOnPlatform>": "<::SensorSlot>"
+      "<ssn:deployedOnPlatform>": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}>"
       "<prov:startedAtTime>": "{START_DATETIME|asDateTime}"
       "<fdri:deployedHeight>": "{INSTALLATION_HEIGHT|asDecimal}"
 

--- a/sample_data/templates/site_slots.yaml
+++ b/sample_data/templates/site_slots.yaml
@@ -1,0 +1,36 @@
+globals:
+    $baseURI: http://fdri.ceh.ac.uk/
+    $datasetID: default
+
+imports:
+    - namespaces.yaml
+    - extensions.py
+
+resources:
+  - name: SensorSlotNameAnnotation
+    requires:
+      SENSOR_SLOT_ID:
+      SENSOR_SLOT_NAME:
+    properties:
+      "@id": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}#sensor-slot-name>"
+      "@type": <fdri:Annotation>
+      "<fdri:property>": "<http://fdri.ceh.ac.uk/ref/common/annotation-property/sensor-slot-name>"
+      "<fdri:hasValue>":
+        - name: SensorSlotName
+          properties:
+            "@id": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}#sensor-slot-name.value>"
+            "@type": <schema:PropertyValue>
+            "<schema:value>": "{SENSOR_SLOT_NAME}"
+
+  - name: SensorSlot
+    requires:
+      SENSOR_SLOT_ID:
+      SENSOR_SLOT_NAME:
+      SITE_ID:
+    properties:
+      "@id": "<http://fdri.ceh.ac.uk/id/platform/cosmos-{SITE_ID|slug}-{SENSOR_SLOT_ID|slug}>"
+      "@type": "<fdri:EnvironmentalMonitoringPlatform>"
+      "<rdfs:label>": "{SENSOR_SLOT_NAME} at {SITE_NAME}@en"
+      "<fdri:hasAnnotation>": "<::SensorSlotNameAnnotation>"
+      "^<dct:hasPart>": "<http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}>"
+


### PR DESCRIPTION
* Add a new derived CSV mapping sites to slots with site name and slot name.
* Add a new template to process this to generate a label and a sensor slot name annotation for each sensor slot at a site
* Remove unused mappings from sensor_deployments mapping

Should address the missing annotations problem reported on #370 