### PR TITLE
staging goes to dev; prod goes to non-dev

### DIFF
--- a/branch.map
+++ b/branch.map
@@ -1,4 +1,4 @@
 branch      sqs_queue_url                                                                                       s3_destination
 dev         https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-dev-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-dev-state/data
-staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data
+staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-dev-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-dev-state/data
 production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data

--- a/branch.map
+++ b/branch.map
@@ -1,4 +1,4 @@
-branch      sqs_queue_url                                                                                       s3_destination
-dev         https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-dev-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-dev-state/data
-staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data
-production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-production-metadata-service-state/data
+branch      sqs_queue_url                                                                                   s3_destination
+dev         https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-state/data
+staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-state/data
+production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo             s3://ukceh-dri-production-metadata-service-state/data

--- a/branch.map
+++ b/branch.map
@@ -1,4 +1,3 @@
 branch      sqs_queue_url                                                                                       s3_destination
-dev         https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-dev-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-dev-state/data
-staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-dev-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-dev-state/data
-production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data
+staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data
+production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-production-metadata-service-state/data

--- a/branch.map
+++ b/branch.map
@@ -1,3 +1,4 @@
-branch      sqs_queue_url                                                                                       s3_destination
-staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data
-production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-production-metadata-service-state/data
+branch      sqs_queue_url                                                                                   s3_destination
+dev         https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-state/data
+staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-state/data
+production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo             s3://ukceh-dri-production-metadata-service-state/data

--- a/branch.map
+++ b/branch.map
@@ -1,4 +1,4 @@
-branch      sqs_queue_url                                                                                   s3_destination
-dev         https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-state/data
-staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-state/data
-production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo             s3://ukceh-dri-production-metadata-service-state/data
+branch      sqs_queue_url                                                                                       s3_destination
+dev         https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-dev-update-queue.fifo             s3://ukceh-dri-staging-metadata-service-dev-state/data
+staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data
+production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-production-metadata-service-state/data


### PR DESCRIPTION
We have decided that the new `staging` AWS account will only contain the `dev` metadata service.

Once accounts are switched we can remove

- the legacy branch map
- the legacy publish
- the `dev` branch (and the `dev` key in the `branch.map`)
- update the workflow accordingly

This will leave just the `staging` and `production` branches we will develop against.