### PR TITLE
Support for upgraded rdf-mapper

### DIFF
--- a/sample_data/templates/STATISTICS.yaml
+++ b/sample_data/templates/STATISTICS.yaml
@@ -7,8 +7,6 @@ imports:
     - concept_schemes.yaml
     - extensions.py
 
-one_offs:
-
 resources:
   - name: StatisticsConcept
     properties:

--- a/sample_data/templates/extensions.py
+++ b/sample_data/templates/extensions.py
@@ -1,9 +1,7 @@
 from rdf_mapper.lib.template_state import TemplateState
-from rdf_mapper.lib.template_support import register_fn, uri_expand
+from rdf_mapper.lib.function import register
+from rdf_mapper.lib.template_support import uri_expand
 from rdflib import Literal
-
-def slug(text: str, state: TemplateState):
-    return '-'.join(text.lower().split()).replace('%', '_').replace('/', '_').replace('[', '_').replace(']', '_')
 
 def with_datatype(text: str, state: TemplateState, dt: str):
     dt_uri = uri_expand(dt, state.spec.namespaces, state)
@@ -16,6 +14,5 @@ def append_fragment(text: str, state: TemplateState, fragment: str, fragment_sep
             return text + fragment_sep + fragment
         return text + '#' + fragment
 
-register_fn('slug', slug)
-register_fn('withDatatype', with_datatype)
-register_fn('append_fragment', append_fragment)
+register('withDatatype', with_datatype)
+register('append_fragment', append_fragment)


### PR DESCRIPTION
* Update extensions to use rdf-mapper 0.3.0 library
* Fix one template which had an empty section that is no longer allowed under the improved validation rules in rdf-mapper 0.3.0