### PR TITLE
Remove unused extension function

### DIFF
--- a/sample_data/templates/extensions.py
+++ b/sample_data/templates/extensions.py
@@ -1,12 +1,5 @@
 from rdf_mapper.lib.template_state import TemplateState
 from rdf_mapper.lib.function import register
-from rdf_mapper.lib.template_support import uri_expand
-from rdflib import Literal
-
-def with_datatype(text: str, state: TemplateState, dt: str):
-    dt_uri = uri_expand(dt, state.spec.namespaces, state)
-    if dt_uri is not None:
-        return Literal(text, datatype=dt_uri)
 
 def append_fragment(text: str, state: TemplateState, fragment: str, fragment_sep: str = '.'):
     if text is not None:
@@ -14,5 +7,4 @@ def append_fragment(text: str, state: TemplateState, fragment: str, fragment_sep
             return text + fragment_sep + fragment
         return text + '#' + fragment
 
-register('withDatatype', with_datatype)
 register('append_fragment', append_fragment)


### PR DESCRIPTION
The withDatatype extension function is no longer used in any template and can be removed.