### PR TITLE
Parameterise source bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,11 @@ TPL = sample_data/templates
 TTL_BASE = build/data
 SHACL_BASE = build/shacl
 SCHEMA_FILE = ontology/schema/fdri.recordspec.yaml
-SOURCE_BUCKET := $(shell awk '$$1==ENVIRON["GITHUB_REF_NAME"] {print $$4}' branch.map)
-SOURCE_BUCKET := $(or ${SOURCE_BUCKET},fdri-discovery-sample-data)
-MAPPER = mapper -g SOURCE_BUCKET=${SOURCE_BUCKET}
+RAW_SOURCE_BUCKET := $(shell awk '$$1==ENVIRON["GITHUB_REF_NAME"] {print $$4}' branch.map)
+RAW_SOURCE_BUCKET := $(or ${RAW_SOURCE_BUCKET},fdri-dummy-ingested)
+PROCESSED_SOURCE_BUCKET := $(shell awk '$$1==ENVIRON["GITHUB_REF_NAME"] {print $$5}' branch.map)
+PROCESSED_SOURCE_BUCKET := $(or ${PROCESSED_SOURCE_BUCKET},fdri-dummy-processed)
+MAPPER = mapper -g RAW_SOURCE_BUCKET=${RAW_SOURCE_BUCKET} -g PROCESSED_SOURCE_BUCKET=${PROCESSED_SOURCE_BUCKET}
 GRIDMAP = gridded-mapper
 
 RECORDS = \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ TPL = sample_data/templates
 TTL_BASE = build/data
 SHACL_BASE = build/shacl
 SCHEMA_FILE = ontology/schema/fdri.recordspec.yaml
-MAPPER = mapper
+SOURCE_BUCKET := $(shell awk '$$1==ENVIRON["GITHUB_REF_NAME"] {print $$4}' branch.map)
+SOURCE_BUCKET := $(or ${SOURCE_BUCKET},fdri-discovery-sample-data)
+MAPPER = mapper -g SOURCE_BUCKET=${SOURCE_BUCKET}
 GRIDMAP = gridded-mapper
 
 RECORDS = \
@@ -133,6 +135,8 @@ SCHEMAS = $(RECORDS:%=build/schema/%.schema.json)
 CONTEXTS = $(RECORDS:%=build/context/%.context.jsonld)
 
 REPORTS = $(SAMPLES:$(TTL_BASE)/%.ttl=$(VAL)/%.ttl)
+
+default: data
 
 data: validate reports full_validation
 all: validate schemas contexts reports full_validation

--- a/branch.map
+++ b/branch.map
@@ -1,3 +1,3 @@
-branch      sqs_queue_url                                                                                       s3_destination
-staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data
-production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-production-metadata-service-state/data
+branch      sqs_queue_url                                                                                       s3_destination                                              s3_source_bucket
+staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data          ukceh-dri-staging-ingested
+production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-production-metadata-service-state/data       ukceh-dri-production-ingested

--- a/branch.map
+++ b/branch.map
@@ -1,3 +1,3 @@
-branch      sqs_queue_url                                                                                       s3_destination                                              s3_source_bucket
-staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data          ukceh-dri-staging-ingested
-production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-production-metadata-service-state/data       ukceh-dri-production-ingested
+branch      sqs_queue_url                                                                                       s3_destination                                              s3_source_bucket_raw            s3_source_bucket_processed
+staging     https://sqs.eu-west-2.amazonaws.com/740991959481/metadata-service-update-queue.fifo                 s3://ukceh-dri-staging-metadata-service-state/data          ukceh-dri-staging-ingested      ukceh-dri-staging-processed
+production  https://sqs.eu-west-2.amazonaws.com/745651872039/metadata-service-update-queue.fifo                 s3://ukceh-dri-production-metadata-service-state/data       ukceh-dri-production-ingested   ukceh-dri-production-processed

--- a/sample_data/src/MEASURES.csv
+++ b/sample_data/src/MEASURES.csv
@@ -5,7 +5,7 @@ WATER_VELOCITY-MS-1,,WATER_VELOCITY,MS-1,,,,Water velocity in metres per second
 WATER_VELOCITY-INST-MS-1,WATER_VELOCITY-MS-1,WATER_VELOCITY,MS-1,INST,,,Instantaneous water velocity in metres per second
 WATER_VELOCITY-MEAN-MS-1,WATER_VELOCITY-MS-1,WATER_VELOCITY,MS-1,MEAN,,,Mean water velocity in metres per second
 WATER_VELOCITY-MAX-MS-1,WATER_VELOCITY-MS-1,WATER_VELOCITY,MS-1,MAX,,,Maximum water velocity in metres per second
-REV-COUNT,,REV,UNITLESS,Number of revolutions,,,Number of revolutions counted in measurement period
+REV-COUNT,,REV,UNITLESS,,,,Number of revolutions counted in measurement period
 REV-TOTAL-COUNT,,REV,UNITLESS,TOTAL,,,Total number of revolutions counted in measurement Period
 ANGULAR_VELOCITY-REVS-1,,ANGULAR_VELOCITY,REVS-1,MEAN,,,Mean angular velocity in revolutions per second
 WATER_TEMP-DEGC,,WATER_TEMP,DEGC,,,,Water temperature in degrees Celsius

--- a/sample_data/templates/MEASURES.yaml
+++ b/sample_data/templates/MEASURES.yaml
@@ -26,7 +26,7 @@ resources:
             "@type": <fdri:Aggregation>
             "<fdri:periodicity>": "{PERIODICITY}^^<xsd:duration>"
             "<fdri:resolution>": "{RESOLUTION}^^<xsd:duration>"
-            "<fdri:valueStatistic>": <http://fdri.ceh.ac.uk/ref/common/staistic/{STAISTIC_ID}>
+            "<fdri:valueStatistic>": "<http://fdri.ceh.ac.uk/ref/common/statistic/{STATISTIC_ID|slug}>"
 
   - name: MeasureParent
     requires:

--- a/sample_data/templates/TIMESERIES_IDS_COSMOS.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_COSMOS.yaml
@@ -1,7 +1,8 @@
 globals:
     $baseURI: http://fdri.ceh.ac.uk/
     $datasetID: default
-    SOURCE_BUCKET: fdri-discovery-sample-data
+    RAW_SOURCE_BUCKET: fdri-discovery-raw-data
+    PROCESSED_SOURCE_BUCKET: fdri-discovery-processed-data
 
 imports:
     - namespaces.yaml
@@ -24,7 +25,15 @@ resources:
       # "<sosa:observedProperty>": "<http://fdri.ceh.ac.uk/ref/common/cop/{PARAMETER_ID|slug}>"
       "<fdri:originatingSite>": "<::Site>"
       "<fdri:originatingProgramme>": "<http://fdri.ceh.ac.uk/id/programme/cosmos>"
-      "<fdri:sourceBucket>": "{SOURCE_BUCKET}"
+      "<fdri:sourceBucket>":
+        - name: RAW_BUCKET
+          requires:
+            PROCESS_LEVEL: RAW
+          pattern: "{RAW_SOURCE_BUCKET}"
+        - name: PROCESSED_BUCKET
+          requires:
+            PROCESS_LEVEL: PROCESSED
+          pattern: "{PROCESSED_SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"
       "<fdri:sourceTimeColumnName>": "{TIME_COLUMN_NAME}"

--- a/sample_data/templates/TIMESERIES_IDS_COSMOS.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_COSMOS.yaml
@@ -29,10 +29,12 @@ resources:
         - name: RAW_BUCKET
           requires:
             PROCESS_LEVEL: RAW
+            S3_BUCKET:
           pattern: "{RAW_SOURCE_BUCKET}"
         - name: PROCESSED_BUCKET
           requires:
             PROCESS_LEVEL: PROCESSED
+            S3_BUCKET:
           pattern: "{PROCESSED_SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"

--- a/sample_data/templates/TIMESERIES_IDS_COSMOS.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_COSMOS.yaml
@@ -1,6 +1,7 @@
 globals:
     $baseURI: http://fdri.ceh.ac.uk/
     $datasetID: default
+    SOURCE_BUCKET: fdri-discovery-sample-data
 
 imports:
     - namespaces.yaml
@@ -23,7 +24,7 @@ resources:
       # "<sosa:observedProperty>": "<http://fdri.ceh.ac.uk/ref/common/cop/{PARAMETER_ID|slug}>"
       "<fdri:originatingSite>": "<::Site>"
       "<fdri:originatingProgramme>": "<http://fdri.ceh.ac.uk/id/programme/cosmos>"
-      "<fdri:sourceBucket>": "{S3_BUCKET}"
+      "<fdri:sourceBucket>": "{SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"
       "<fdri:sourceTimeColumnName>": "{TIME_COLUMN_NAME}"

--- a/sample_data/templates/TIMESERIES_IDS_FDRI.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_FDRI.yaml
@@ -28,10 +28,12 @@ resources:
         - name: RAW_BUCKET
           requires:
             PROCESS_LEVEL: RAW
+            S3_BUCKET:
           pattern: "{RAW_SOURCE_BUCKET}"
         - name: PROCESSED_BUCKET
           requires:
             PROCESS_LEVEL: PROCESSED
+            S3_BUCKET:
           pattern: "{PROCESSED_SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"

--- a/sample_data/templates/TIMESERIES_IDS_FDRI.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_FDRI.yaml
@@ -22,7 +22,7 @@ resources:
       "<sosa:observedProperty>": "<http://fdri.ceh.ac.uk/ref/common/cop/{PARAMETER_ID|slug}>"
       "<fdri:originatingSite>": "<::Site>"
       "<fdri:originatingProgramme>": "<http://fdri.ceh.ac.uk/id/programme/fdri>"
-      "<fdri:sourceBucket>": "{S3_BUCKET}"
+      "<fdri:sourceBucket>": "{SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"
       "<fdri:sourceTimeColumnName>": "{TIME_COLUMN_NAME}"

--- a/sample_data/templates/TIMESERIES_IDS_FDRI.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_FDRI.yaml
@@ -1,6 +1,8 @@
 globals:
     $baseURI: http://fdri.ceh.ac.uk/
     $datasetID: default
+    RAW_SOURCE_BUCKET: fdri-discovery-raw-data
+    PROCESSED_SOURCE_BUCKET: fdri-discovery-processed-data
 
 imports:
     - namespaces.yaml
@@ -22,7 +24,15 @@ resources:
       "<sosa:observedProperty>": "<http://fdri.ceh.ac.uk/ref/common/cop/{PARAMETER_ID|slug}>"
       "<fdri:originatingSite>": "<::Site>"
       "<fdri:originatingProgramme>": "<http://fdri.ceh.ac.uk/id/programme/fdri>"
-      "<fdri:sourceBucket>": "{SOURCE_BUCKET}"
+      "<fdri:sourceBucket>":
+        - name: RAW_BUCKET
+          requires:
+            PROCESS_LEVEL: RAW
+          pattern: "{RAW_SOURCE_BUCKET}"
+        - name: PROCESSED_BUCKET
+          requires:
+            PROCESS_LEVEL: PROCESSED
+          pattern: "{PROCESSED_SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"
       "<fdri:sourceTimeColumnName>": "{TIME_COLUMN_NAME}"

--- a/sample_data/templates/TIMESERIES_IDS_NMDB.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_NMDB.yaml
@@ -1,6 +1,8 @@
 globals:
     $baseURI: http://fdri.ceh.ac.uk/
     $datasetID: default
+    RAW_SOURCE_BUCKET: fdri-discovery-raw-data
+    PROCESSED_SOURCE_BUCKET: fdri-discovery-processed-data
 
 imports:
     - namespaces.yaml
@@ -22,7 +24,15 @@ resources:
       "<sosa:observedProperty>": "<http://fdri.ceh.ac.uk/ref/common/cop/{PARAMETER_ID|slug}>"
       "<fdri:originatingSite>": "<::Site>"
       "<fdri:originatingProgramme>": "<http://fdri.ceh.ac.uk/id/programme/nmdb>"
-      "<fdri:sourceBucket>": "{SOURCE_BUCKET}"
+      "<fdri:sourceBucket>":
+        - name: RAW_BUCKET
+          requires:
+            PROCESS_LEVEL: RAW
+          pattern: "{RAW_SOURCE_BUCKET}"
+        - name: PROCESSED_BUCKET
+          requires:
+            PROCESS_LEVEL: PROCESSED
+          pattern: "{PROCESSED_SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"
       "<fdri:sourceTimeColumnName>": "{TIME_COLUMN_NAME}"

--- a/sample_data/templates/TIMESERIES_IDS_NMDB.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_NMDB.yaml
@@ -28,10 +28,12 @@ resources:
         - name: RAW_BUCKET
           requires:
             PROCESS_LEVEL: RAW
+            S3_BUCKET:
           pattern: "{RAW_SOURCE_BUCKET}"
         - name: PROCESSED_BUCKET
           requires:
             PROCESS_LEVEL: PROCESSED
+            S3_BUCKET:
           pattern: "{PROCESSED_SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"

--- a/sample_data/templates/TIMESERIES_IDS_NMDB.yaml
+++ b/sample_data/templates/TIMESERIES_IDS_NMDB.yaml
@@ -22,7 +22,7 @@ resources:
       "<sosa:observedProperty>": "<http://fdri.ceh.ac.uk/ref/common/cop/{PARAMETER_ID|slug}>"
       "<fdri:originatingSite>": "<::Site>"
       "<fdri:originatingProgramme>": "<http://fdri.ceh.ac.uk/id/programme/nmdb>"
-      "<fdri:sourceBucket>": "{S3_BUCKET}"
+      "<fdri:sourceBucket>": "{SOURCE_BUCKET}"
       "<fdri:sourceDataset>": "{S3_DATASET}"
       "<fdri:sourceColumnName>": "{COLUMN_NAME}"
       "<fdri:sourceTimeColumnName>": "{TIME_COLUMN_NAME}"


### PR DESCRIPTION
Fixes #421 

- Add branch.map columns to specify the raw and processed data bucket for each environment
- Update to a new version of rdf-mapper that allows additional global variable to be passed via the command line
- Update the  Makefile to invoke rdf-mapper with the bucket locations as new globals
- Update the mappings that specify the source bucket to use the variable set on the command line rather than the value in the CSV
- Fix a couple of issues in the mapping of measures that were causing the final validation of the generated data to break 