### PR TITLE
Simplify the flux metadata to fix the build

### DIFF
--- a/sample_data/templates/flux_processing_configs.yaml
+++ b/sample_data/templates/flux_processing_configs.yaml
@@ -58,44 +58,29 @@ embedded:
             "<fdri:argument>": "{structured_value | map_to(NestedMethodArgument)}"
 
 resources:
-  - name: FluxDataset
+  - name: FluxProcessingConfiguration
     properties:
-      "@id": "<{applies_to_dataset}>"
-      "<fdri:directDependsOn>":
-        - name: DependsOn
-          requires:
-            depends_on:
-          template: "<{depends_on}>"
-      "<fdri:methodology>":
-        - name: FluxProcessingPlan
+      "@id": "<http://fdri.ceh.ac.uk/id/data-processing-configuration/{config_id|slug}>"
+      "@type": "<fdri:InternalDataProcessingConfiguration>"
+      "<dct:type>":
+        - name: ProcessingConfigType
           properties:
-            "@id": "<http://fdri.ceh.ac.uk/id/plan/{config_id|slug}>"
-            "@type": "<fdri:TimeSeriesPlan>"
-            "<fdri:uses>": <{depends_on}>
-            "<fdri:rawConfiguration>": "{raw}"
-            "<fdri:configuration>":
-              - name: FluxProcessingConfiguration
+            "@id": "<http://fdri.ceh.ac.uk/ref/common/configuration-type/{config_type|slug}>"
+            "@type": "<fdri:DataProcessingConfigurationType>"
+            "<skos:inScheme>": "<::ConfigurationTypeScheme>"
+            "^<skos:hasTopConcept>": "<::ConfigurationTypeScheme>"
+      "<fdri:appliesToDataset>": "<{applies_to_dataset}>"
+      "<fdri:rawConfiguration>": "{raw}"
+      "<fdri:hasCurrentValue>":
+        - name: FluxProcessingConfigItem
+          properties:
+            "@id": "<http://fdri.ceh.ac.uk/id/configuration-item/{config_id|slug}-current>"
+            "@type": "<fdri:ConfigurationItem>"
+            "<fdri:method>":
+              - name: FluxProcessingMethod
                 properties:
-                  "@id": "<http://fdri.ceh.ac.uk/id/data-processing-configuration/{config_id|slug}>"
-                  "@type": "<fdri:InternalDataProcessingConfiguration>"
-                  "<dct:type>":
-                    - name: ProcessingConfigType
-                      properties:
-                        "@id": "<http://fdri.ceh.ac.uk/ref/common/configuration-type/{config_type|slug}>"
-                        "@type": "<fdri:DataProcessingConfigurationType>"
-                        "<skos:inScheme>": "<::ConfigurationTypeScheme>"
-                        "^<skos:hasTopConcept>": "<::ConfigurationTypeScheme>"
-                  "<fdri:appliesToDataset>": "<{applies_to_dataset}>"
-                  "<fdri:hasCurrentValue>":
-                    - name: FluxProcessingConfigItem
-                      properties:
-                        "@id": "<http://fdri.ceh.ac.uk/id/configuration-item/{config_id|slug}-current>"
-                        "@type": "<fdri:ConfigurationItem>"
-                        "<fdri:method>":
-                          - name: FluxProcessingMethod
-                            properties:
-                              "@id": "<http://fdri.ceh.ac.uk/ref/common/method/{method|slug}>"
-                              "@type": "<fdri:DataProcessingMethod>"
-                              "<skos:inScheme>": "<::DataProcessingMethodScheme>"
-                              "^<skos:hasTopConcept>": "<::DataProcessingMethodScheme>"
-                        "<fdri:argument>": "{param_entries | map_to(MethodArgument)}"
+                  "@id": "<http://fdri.ceh.ac.uk/ref/common/method/{method|slug}>"
+                  "@type": "<fdri:DataProcessingMethod>"
+                  "<skos:inScheme>": "<::DataProcessingMethodScheme>"
+                  "^<skos:hasTopConcept>": "<::DataProcessingMethodScheme>"
+            "<fdri:argument>": "{param_entries | map_to(MethodArgument)}"


### PR DESCRIPTION
I've removed the `fdri:TimeSeriesPlan` element from the metadata templates for the flux datasets. The build is breaking because the current version of the model specifies that a plan has a single configuration and the flux templates are generating multiple configurations for some plans.

 This part of the ontology is in the process of changing (and will in the future allow multiple steps), and in any case the current need is just for a list of data processing configurations that apply to a given dataset all of which can be done without the need for the fdri:TimeSeriesPlan.

I see this as a temporary measure to ensure that the data in this repo continues to build without validation errors.