### PR TITLE
Wrap load_ts values as an object with an id property

### DIFF
--- a/sample_data/sql/processing_configurations.jq
+++ b/sample_data/sql/processing_configurations.jq
@@ -1,1 +1,1 @@
-to_entries | map(.key as $site | .value | map(. + {"site": $site})) | flatten | .[] | . + {"raw": . | tostring} | if .dep_ts then . + {"dep_ts": .dep_ts | map({"id": .})} else . end
+to_entries | map(.key as $site | .value | map(. + {"site": $site})) | flatten | .[] | . + {"raw": . | tostring} | if .dep_ts then . + {"dep_ts": .dep_ts | map({"id": .})} else . end | if .load_ts then . + {"load_ts": .load_ts | map({"id": .})} else . end

--- a/sample_data/templates/processing_configurations.yaml
+++ b/sample_data/templates/processing_configurations.yaml
@@ -60,6 +60,6 @@ resources:
                 properties:
                   "@id": "<http://fdri.ceh.ac.uk/id/configuration-item/{id}#argument.loadts>"
                   "@type": "<fdri:ConfigurationItemArgument>"
-                  "<fdri:parameter>": "<http://fdri.ceh.ac.uk/ref/common/parameter/load_ts>"
+                  "<fdri:parameter>": "<http://fdri.ceh.ac.uk/ref/common/parameter/load_dep_ts>"
                   "<fdri:hasValue>": "{load_ts|map_to(DepTimeSeriesValue)}"
 


### PR DESCRIPTION
Fix an issue with the load_ts value not being processed. To go through the template the array of strings needs to be changed to an array of objects with an id property (in the same way as already done for dep_ts).