### PR TITLE
Add input dataset to dependencies

### DIFF
--- a/sample_data/templates/processing_plans.yaml
+++ b/sample_data/templates/processing_plans.yaml
@@ -23,7 +23,7 @@ resources:
   - name: OutputDataset
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/dataset/{output|slug}>"
-      "<fdri:directDepndsOn>": "<http://fdri.ceh.ac.uk/id/dataset/{input|slug}>"
+      "<fdri:directDependsOn>": "<http://fdri.ceh.ac.uk/id/dataset/{input|slug}>"
       
   - name: DataProcessingPlan
     properties:

--- a/sample_data/templates/processing_plans.yaml
+++ b/sample_data/templates/processing_plans.yaml
@@ -20,11 +20,17 @@ embedded:
             "<fdri:appliesToDataset>": "<http://fdri.ceh.ac.uk/id/dataset/{output|slug}>"
 
 resources:
+  - name: OutputDataset
+    properties:
+      "@id": "<http://fdri.ceh.ac.uk/id/dataset/{output|slug}>"
+      "<fdri:directDepndsOn>": "<http://fdri.ceh.ac.uk/id/dataset/{input|slug}>"
+      
   - name: DataProcessingPlan
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/plan/{id}>"
       "@type": "<fdri:TimeSeriesPlan>"
-      "^<fdri:methodology>": "<http://fdri.ceh.ac.uk/id/dataset/{output|slug}>"
+      "^<fdri:methodology>": "<::OutputDataset>"
+      "<fdri:uses>": "<http://fdri.ceh.ac.uk/id/dataset/{input|slug}>"
       "<dct:hasPart>": "{steps|map_to(DataProcessingStep)}"
       "<fdri:rawConfiguration>": "{steps_raw}"
   


### PR DESCRIPTION
The `input` property in the data processing configurations was not being mapped as a dataset dependency.
This PR adds an fdri:directDependsOn between the input dataset and the output dataset, and also adds the input dataset to the referenced fdri:TimeSeriesPlan using the fdri:uses property.