### PR TITLE
Update flux configs and plans for post-eddypro datasets

### DIFF
--- a/sample_data/src/processing_configurations_flux.json
+++ b/sample_data/src/processing_configurations_flux.json
@@ -1,6 +1,11 @@
 {
   "flux-plynl": [
     {
+      "id": "flux-plynl-raw-load-local-copy",
+      "type": "load",
+      "method": "load-local-copy"
+    },
+    {
       "id": "flux-plynl-eddypro",
       "type": "calculate",
       "method": "eddypro-run",
@@ -655,72 +660,11 @@
       ]
     },
     {
-      "id": "flux-plynl-raw-load-local-copy",
-      "type": "load",
-      "method": "load-local-copy"
-    },
-    {
-      "id": "flux-plynl-biomet-ta-load-raw",
-      "type": "load",
-      "method": "load",
-      "dep_ts": [
-        "flux-plynl-biomet-ta"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-rh-load-raw",
-      "type": "load",
-      "method": "load",
-      "dep_ts": [
-        "flux-plynl-biomet-rh"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-pa-load-raw",
-      "type": "load",
-      "method": "load",
-      "dep_ts": [
-        "flux-plynl-biomet-pa"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-shf1-load-raw",
-      "type": "load",
-      "method": "load",
-      "dep_ts": [
-        "flux-plynl-biomet-shf1"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-shf2-load-raw",
-      "type": "load",
-      "method": "load",
-      "dep_ts": [
-        "flux-plynl-biomet-shf2"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-rn-load-raw",
-      "type": "load",
-      "method": "load",
-      "dep_ts": [
-        "flux-plynl-biomet-rn"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-swin-load-raw",
-      "type": "load",
-      "method": "load",
-      "dep_ts": [
-        "flux-plynl-biomet-swin"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-ta-30min-aggregate",
+      "id": "flux-plynl-biomet-pa-30min-aggregate",
       "type": "aggregate",
       "method": "mean",
       "dep_ts": [
-        "flux-plynl-biomet-ta"
+        "flux-plynl-biomet-pa"
       ]
     },
     {
@@ -732,11 +676,11 @@
       ]
     },
     {
-      "id": "flux-plynl-biomet-pa-30min-aggregate",
+      "id": "flux-plynl-biomet-rn-30min-aggregate",
       "type": "aggregate",
       "method": "mean",
       "dep_ts": [
-        "flux-plynl-biomet-pa"
+        "flux-plynl-biomet-rn"
       ]
     },
     {
@@ -756,11 +700,12 @@
       ]
     },
     {
-      "id": "flux-plynl-biomet-rn-30min-aggregate",
-      "type": "aggregate",
-      "method": "mean",
+      "id": "flux-plynl-shf-derivation",
+      "type": "calculate",
+      "method": "calc_flux_mean_shf",
       "dep_ts": [
-        "flux-plynl-biomet-rn"
+        "flux-plynl-biomet-shf1-30min",
+        "flux-plynl-biomet-shf2-30min"
       ]
     },
     {
@@ -772,11 +717,75 @@
       ]
     },
     {
+      "id": "flux-plynl-biomet-ta-30min-aggregate",
+      "type": "aggregate",
+      "method": "mean",
+      "dep_ts": [
+        "flux-plynl-biomet-ta"
+      ]
+    },
+    {
+      "id": "flux-plynl-co2-flux-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-h-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
       "id": "flux-plynl-h-qc-flag",
       "type": "qc",
       "method": "flux_qc_flag",
       "dep_ts": [
         "flux-plynl-qc-h"
+      ]
+    },
+    {
+      "id": "flux-plynl-h2o-flux-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-qc-h-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-qc-tau-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-sonic-temp-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-tau-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
       ]
     },
     {
@@ -788,12 +797,69 @@
       ]
     },
     {
-      "id": "flux-plynl-shf-derivation",
-      "type": "calculate",
-      "method": "calc_flux_mean_shf",
+      "id": "flux-plynl-u-var-load",
+      "type": "load",
+      "method": "load",
       "dep_ts": [
-        "flux-plynl-biomet-shf1-30min",
-        "flux-plynl-biomet-shf2-30min"
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-v-var-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-vpd-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-w-var-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-wind-dir-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-wind-speed-load",
+      "type": "load",
+      "method": "load",
+      "dep_ts": [
+        "flux-plynl-processed"
+      ]
+    },
+    {
+      "id": "flux-plynl-et-l1-derivation",
+      "type": "calculate",
+      "method": "calc_flux_et_l1",
+      "dep_ts": [
+        "flux-plynl-le-l1",
+        "flux-plynl-biomet-ta-30min"
+      ]
+    },
+    {
+      "id": "flux-plynl-et-l2-derivation",
+      "type": "calculate",
+      "method": "calc_flux_et_l2",
+      "dep_ts": [
+        "flux-plynl-le-l2",
+        "flux-plynl-biomet-ta-30min"
       ]
     },
     {
@@ -822,15 +888,6 @@
       ]
     },
     {
-      "id": "flux-plynl-et-l1-derivation",
-      "type": "calculate",
-      "method": "calc_flux_et_l1",
-      "dep_ts": [
-        "flux-plynl-le-l1",
-        "flux-plynl-biomet-ta-30min"
-      ]
-    },
-    {
       "id": "flux-plynl-le-l2-derivation",
       "type": "calculate",
       "method": "calc_flux_le_l2",
@@ -853,15 +910,6 @@
           "param": "gt",
           "value": 600.0
         }
-      ]
-    },
-    {
-      "id": "flux-plynl-et-l2-derivation",
-      "type": "calculate",
-      "method": "calc_flux_et_l2",
-      "dep_ts": [
-        "flux-plynl-le-l2",
-        "flux-plynl-biomet-ta-30min"
       ]
     }
   ]

--- a/sample_data/src/processing_plans_flux.json
+++ b/sample_data/src/processing_plans_flux.json
@@ -1,110 +1,10 @@
 {
   "flux-plynl": [
     {
-      "id": "flux-plynl-biomet-pa-30min-plan",
-      "output": "flux-plynl-biomet-pa-30min",
-      "input": "flux-plynl-biomet-pa",
+      "id": "flux-plynl-raw-plan",
+      "output": "flux-plynl-raw",
       "steps": [
-        "flux-plynl-biomet-pa-load-raw",
-        "flux-plynl-biomet-pa-30min-aggregate"
-      ]
-    },
-    {
-      "id": "flux-plynl-et-l2-plan",
-      "output": "flux-plynl-et-l2",
-      "steps": [
-        "flux-plynl-et-l2-derivation"
-      ]
-    },
-    {
-      "id": "flux-plynl-h-l2-plan",
-      "output": "flux-plynl-h-l2",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-co2-flux-plan",
-      "output": "flux-plynl-co2-flux",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-h-despiked-plan",
-      "output": "flux-plynl-h-despiked",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-u-var-plan",
-      "output": "flux-plynl-u-var",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-sonic-temp-plan",
-      "output": "flux-plynl-sonic-temp",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-tau-l2-plan",
-      "output": "flux-plynl-tau-l2",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-biomet-rn-30min-plan",
-      "output": "flux-plynl-biomet-rn-30min",
-      "input": "flux-plynl-biomet-rn",
-      "steps": [
-        "flux-plynl-biomet-rn-load-raw",
-        "flux-plynl-biomet-rn-30min-aggregate"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-rh-30min-plan",
-      "output": "flux-plynl-biomet-rh-30min",
-      "input": "flux-plynl-biomet-rh",
-      "steps": [
-        "flux-plynl-biomet-rh-load-raw",
-        "flux-plynl-biomet-rh-30min-aggregate"
-      ]
-    },
-    {
-      "id": "flux-plynl-shf-plan",
-      "output": "flux-plynl-shf",
-      "steps": [
-        "flux-plynl-shf-derivation"
-      ]
-    },
-    {
-      "id": "flux-plynl-vpd-plan",
-      "output": "flux-plynl-vpd",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-qc-h-plan",
-      "output": "flux-plynl-qc-h",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-biomet-shf2-30min-plan",
-      "output": "flux-plynl-biomet-shf2-30min",
-      "input": "flux-plynl-biomet-shf2",
-      "steps": [
-        "flux-plynl-biomet-shf2-load-raw",
-        "flux-plynl-biomet-shf2-30min-aggregate"
-      ]
-    },
-    {
-      "id": "flux-plynl-biomet-swin-30min-plan",
-      "output": "flux-plynl-biomet-swin-30min",
-      "input": "flux-plynl-biomet-swin",
-      "steps": [
-        "flux-plynl-biomet-swin-load-raw",
-        "flux-plynl-biomet-swin-30min-aggregate"
+        "flux-plynl-raw-load-local-copy"
       ]
     },
     {
@@ -116,12 +16,159 @@
       ]
     },
     {
+      "id": "flux-plynl-biomet-pa-30min-plan",
+      "output": "flux-plynl-biomet-pa-30min",
+      "input": "flux-plynl-biomet-pa",
+      "steps": [
+        "flux-plynl-biomet-pa-30min-aggregate"
+      ]
+    },
+    {
+      "id": "flux-plynl-biomet-rh-30min-plan",
+      "output": "flux-plynl-biomet-rh-30min",
+      "input": "flux-plynl-biomet-rh",
+      "steps": [
+        "flux-plynl-biomet-rh-30min-aggregate"
+      ]
+    },
+    {
+      "id": "flux-plynl-biomet-rn-30min-plan",
+      "output": "flux-plynl-biomet-rn-30min",
+      "input": "flux-plynl-biomet-rn",
+      "steps": [
+        "flux-plynl-biomet-rn-30min-aggregate"
+      ]
+    },
+    {
       "id": "flux-plynl-biomet-shf1-30min-plan",
       "output": "flux-plynl-biomet-shf1-30min",
       "input": "flux-plynl-biomet-shf1",
       "steps": [
-        "flux-plynl-biomet-shf1-load-raw",
         "flux-plynl-biomet-shf1-30min-aggregate"
+      ]
+    },
+    {
+      "id": "flux-plynl-biomet-shf2-30min-plan",
+      "output": "flux-plynl-biomet-shf2-30min",
+      "input": "flux-plynl-biomet-shf2",
+      "steps": [
+        "flux-plynl-biomet-shf2-30min-aggregate"
+      ]
+    },
+    {
+      "id": "flux-plynl-shf-plan",
+      "output": "flux-plynl-shf",
+      "steps": [
+        "flux-plynl-shf-derivation"
+      ]
+    },
+    {
+      "id": "flux-plynl-biomet-swin-30min-plan",
+      "output": "flux-plynl-biomet-swin-30min",
+      "input": "flux-plynl-biomet-swin",
+      "steps": [
+        "flux-plynl-biomet-swin-30min-aggregate"
+      ]
+    },
+    {
+      "id": "flux-plynl-biomet-ta-30min-plan",
+      "output": "flux-plynl-biomet-ta-30min",
+      "input": "flux-plynl-biomet-ta",
+      "steps": [
+        "flux-plynl-biomet-ta-30min-aggregate"
+      ]
+    },
+    {
+      "id": "flux-plynl-co2-flux-plan",
+      "output": "flux-plynl-co2-flux",
+      "steps": [
+        "flux-plynl-co2-flux-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-h-plan",
+      "output": "flux-plynl-h",
+      "steps": [
+        "flux-plynl-h-load",
+        "flux-plynl-h-qc-flag"
+      ]
+    },
+    {
+      "id": "flux-plynl-h2o-flux-plan",
+      "output": "flux-plynl-h2o-flux",
+      "steps": [
+        "flux-plynl-h2o-flux-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-qc-h-plan",
+      "output": "flux-plynl-qc-h",
+      "steps": [
+        "flux-plynl-qc-h-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-qc-tau-plan",
+      "output": "flux-plynl-qc-tau",
+      "steps": [
+        "flux-plynl-qc-tau-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-sonic-temp-plan",
+      "output": "flux-plynl-sonic-temp",
+      "steps": [
+        "flux-plynl-sonic-temp-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-tau-plan",
+      "output": "flux-plynl-tau",
+      "steps": [
+        "flux-plynl-tau-load",
+        "flux-plynl-tau-qc-flag"
+      ]
+    },
+    {
+      "id": "flux-plynl-u-var-plan",
+      "output": "flux-plynl-u-var",
+      "steps": [
+        "flux-plynl-u-var-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-v-var-plan",
+      "output": "flux-plynl-v-var",
+      "steps": [
+        "flux-plynl-v-var-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-vpd-plan",
+      "output": "flux-plynl-vpd",
+      "steps": [
+        "flux-plynl-vpd-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-w-var-plan",
+      "output": "flux-plynl-w-var",
+      "steps": [
+        "flux-plynl-w-var-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-wind-dir-plan",
+      "output": "flux-plynl-wind-dir",
+      "steps": [
+        "flux-plynl-wind-dir-load"
+      ]
+    },
+    {
+      "id": "flux-plynl-wind-speed-plan",
+      "output": "flux-plynl-wind-speed",
+      "steps": [
+        "flux-plynl-wind-speed-load"
       ]
     },
     {
@@ -132,51 +179,11 @@
       ]
     },
     {
-      "id": "flux-plynl-raw-plan",
-      "output": "flux-plynl-raw",
+      "id": "flux-plynl-et-l2-plan",
+      "output": "flux-plynl-et-l2",
       "steps": [
-        "flux-plynl-raw-load-local-copy"
+        "flux-plynl-et-l2-derivation"
       ]
-    },
-    {
-      "id": "flux-plynl-w-var-plan",
-      "output": "flux-plynl-w-var",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-h2o-flux-plan",
-      "output": "flux-plynl-h2o-flux",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-qc-tau-plan",
-      "output": "flux-plynl-qc-tau",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
-      "id": "flux-plynl-tau-plan",
-      "output": "flux-plynl-tau",
-      "input": "flux-plynl-processed",
-      "steps": [
-        "flux-plynl-tau-qc-flag"
-      ]
-    },
-    {
-      "id": "flux-plynl-h-plan",
-      "output": "flux-plynl-h",
-      "input": "flux-plynl-processed",
-      "steps": [
-        "flux-plynl-h-qc-flag"
-      ]
-    },
-    {
-      "id": "flux-plynl-wind-speed-plan",
-      "output": "flux-plynl-wind-speed",
-      "input": "flux-plynl-processed",
-      "steps": []
     },
     {
       "id": "flux-plynl-le-l1-plan",
@@ -187,33 +194,12 @@
       ]
     },
     {
-      "id": "flux-plynl-biomet-ta-30min-plan",
-      "output": "flux-plynl-biomet-ta-30min",
-      "input": "flux-plynl-biomet-ta",
-      "steps": [
-        "flux-plynl-biomet-ta-load-raw",
-        "flux-plynl-biomet-ta-30min-aggregate"
-      ]
-    },
-    {
-      "id": "flux-plynl-v-var-plan",
-      "output": "flux-plynl-v-var",
-      "input": "flux-plynl-processed",
-      "steps": []
-    },
-    {
       "id": "flux-plynl-le-l2-plan",
       "output": "flux-plynl-le-l2",
       "steps": [
         "flux-plynl-le-l2-derivation",
         "flux-plynl-le-l2-range"
       ]
-    },
-    {
-      "id": "flux-plynl-wind-dir-plan",
-      "output": "flux-plynl-wind-dir",
-      "input": "flux-plynl-processed",
-      "steps": []
     }
   ]
 }


### PR DESCRIPTION
Tidying up flux dataset configurations and plans

- Added explicit 'load' steps for post-eddypro variables that get their data from the big eddypro output dataframe
- Remove some unrequired load steps for the biomet vars

## Questions

- Tau_L2, H_L2, H_despiked are not in eddypro output.  There are no "plans" for these datasets yet as not clear what creates them.

The following don't exist as a derivation_method yet, so datasets referencing these methods in their configurations will fail the pipeline:
- calc_flux_et_l1 
- calc_flux_et_l2
- calc_flux_le_l1
- calc_flux_le_l2

Note there is a "calc_flux_et" derivation_method.  Should that be renamed?