### PR TITLE
Use PLYNL as primary identifier for flux-plynl site

### DIFF
--- a/sample_data/src/flux/sites.json
+++ b/sample_data/src/flux/sites.json
@@ -3,9 +3,8 @@
     {
       "site_id": "http://fdri.ceh.ac.uk/id/site/flux-plynl",
       "network": "fdri",
-      "alt_id": "flux-plynl",
+      "alt_id": "PLYNL",
       "identifiers": [
-        "flux-plynl",
         "PLYNL"
       ],
       "full_name": "Plynlimon flux tower",


### PR DESCRIPTION
The flux-plynl site had two identifiers: ["flux-plynl", "PLYNL"]. 
The timeseries processor uses identifier[0] as the S3 partition 
key, so processed data was being written to site=flux-plynl rather 
than site=PLYNL like other networks