### PR TITLE
Fix EddyPro flux output measure time anchors from INST to MEAN_PREC

### DIFF
--- a/sample_data/src/MEASURES.csv
+++ b/sample_data/src/MEASURES.csv
@@ -45,8 +45,10 @@ FACTOR_INTEN-INST-UNITLESS-PT1H-PT1H,,FACTOR_INTEN,UNITLESS,NONE,INST,PT1H,PT1H,
 FACTOR_PA-INST-UNITLESS-PT1H-PT1H,,FACTOR_PA,UNITLESS,NONE,INST,PT1H,PT1H,Instantaneous pressure facctor (unitless)
 FACTOR_Q-INST-UNITLESS-PT1H-PT1H,,FACTOR_Q,UNITLESS,NONE,INST,PT1H,PT1H,Instantaneous water vapour factor (unitless)
 FLUX_MOM-INST-KGM-1S-2-PT30M-PT30M,,FLUX_MOM,KGM-1S-2,NONE,INST,PT30M,PT30M,Instantaneous momentum flux in kilograms per metre per second squared
+FLUX_MOM-MEAN_PREC-KGM-1S-2-PT30M-PT30M,,FLUX_MOM,KGM-1S-2,MEAN,PREC,PT30M,PT30M,Mean momentum flux over the preceding 30 minutes in kilograms per metre per second squared
 FRICTIONV-INST-MS-1-PT30M-PT30M,,FRICTIONV,MS-1,NONE,INST,PT30M,PT30M,Instantaneous friction velocity in metres per second
 HEATFLUX_SENSIBLE-INST-WM-2-PT30M-PT30M,,HEATFLUX_SENSIBLE,WM-2,NONE,INST,PT30M,PT30M,Instantaneous sensible heat flux in watts per metre squared
+HEATFLUX_SENSIBLE-MEAN_PREC-WM-2-PT30M-PT30M,,HEATFLUX_SENSIBLE,WM-2,MEAN,PREC,PT30M,PT30M,Mean sensible heat flux over the preceding 30 minutes in watts per metre squared
 HEATFLUX_SOIL_CAL-INST-UNITLESS-PT30M-PT30M,,HEATFLUX_SOIL_CAL,UNITLESS,NONE,INST,PT30M,PT30M,Instantaneous soil heat flux calibration factor (unitless)
 HEATFLUX_SOIL_MV-INST-MV-PT30M-PT30M,,HEATFLUX_SOIL_MV,MV,NONE,INST,PT30M,PT30M,Instantaneous soil heat flux in millivolts
 HEATFLUX_SOIL_STD-STDDEV_PREC-WM-2-PT30M-PT30M,,HEATFLUX_SOIL_STD,WM-2,STDDEV,PREC,PT30M,PT30M,Standard deviation of soil heat flux in watts per metre squared over preceding 30 minutes
@@ -200,6 +202,7 @@ TEMP_SOIL_50-MEAN_PROC-DEGC-P1D-P1D,,TEMP_SOIL_50,DEGC,MEAN,PROC,P1D,P1D,Mean so
 TEMP_SOIL_50-MEAN_PREC-DEGC-PT30M-PT30M,,TEMP_SOIL_50,DEGC,MEAN,PREC,PT30M,PT30M,Mean soil temperature at 50 cm depth over the preceding 30 minutes in degrees Celsius
 TEMP_SONIC_STD-STDDEV_PREC-MS-1-PT30M-PT30M,,TEMP_SONIC_STD,MS-1,STDDEV,PREC,PT30M,PT30M,Standard deviation of sonic temperature over the preceding 30 minutes in meters per second
 TEMP_SONIC-INST-DEGC-PT30M-PT30M,,TEMP_SONIC,DEGC,NONE,INST,PT30M,PT30M,Instantaneous sonic temperature in degrees Celsius
+TEMP_SONIC-MEAN_PREC-DEGC-PT30M-PT30M,,TEMP_SONIC,DEGC,MEAN,PREC,PT30M,PT30M,Mean sonic temperature over the preceding 30 minutes in degrees Celsius
 UNCERTAINTY-MEAN_PROC-MM-P1D-P1D,,UNCERTAINTY,MM,MEAN,PROC,P1D,P1D,Mean uncertainty of snow water equivalent over the proceeding day in millimetres
 UNCERTAINTY-MEAN_PREC-MM-PT1H-PT1H,,UNCERTAINTY,MM,MEAN,PREC,PT1H,PT1H,Mean uncertainty of snow water equivalent over the preceding hour in millimetres
 UX_STD-STDDEV_PREC-MS-1-PT30M-PT30M,,UX_STD,MS-1,STDDEV,PREC,PT30M,PT30M,Standard deviation of X component of wind speed in meters per second
@@ -277,20 +280,20 @@ TEMP_SOIL_50-MEAN_PREC-DEGC-PT15M-PT15M,,TEMP_SOIL_50,DEGC,MEAN,PREC,PT15M,PT15M
 PROP_PERIOD-MEAN_PREC-UNITLESS-PT15M-PT15M,,PROP_PERIOD,UNITLESS,MEAN,PREC,PT15M,PT15M,Mean instrument period over preceding 15 minutes (unitless)
 PROP_PERIOD-MEAN_PREC-SEC-PT15M-PT15M,,PROP_PERIOD,SEC,MEAN,PREC,PT15M,PT15M,Mean instrument period over preceding 15 minutes in seconds
 VOLTAGE_RATIO-MEAN_PREC-UNITLESS-PT15M-PT15M,,VOLTAGE_RATIO,UNITLESS,MEAN,PREC,PT15M,PT15M,Mean voltage ratio over the preceding 15 minutes (unitless)
-CO2_FLUX-INST-UMOLM-2S-1-PT30M-PT30M,,CO2_FLUX,UMOLM-2S-1,NONE,INST,PT30M,PT30M,Instantaneous CO2 flux in micromoles per metre squared per second
-ET-INST-MM-PT30M-PT30M,,ET,MM,NONE,INST,PT30M,PT30M,Instantaneous evapotranspiration in millimetres
-H2O_FLUX-INST-MMOLM-2S-1-PT30M-PT30M,,H2O_FLUX,MMOLM-2S-1,NONE,INST,PT30M,PT30M,Instantaneous H2O flux in millimoles per metre squared per second
-HEATFLUX_LATENT-INST-WM-2-PT30M-PT30M,,HEATFLUX_LATENT,WM-2,NONE,INST,PT30M,PT30M,Instantaneous latent heat flux in watts per metre squared
+CO2_FLUX-MEAN_PREC-UMOLM-2S-1-PT30M-PT30M,,CO2_FLUX,UMOLM-2S-1,MEAN,PREC,PT30M,PT30M,Mean CO2 flux over the preceding 30 minutes in micromoles per metre squared per second
+ET-MEAN_PREC-MM-PT30M-PT30M,,ET,MM,MEAN,PREC,PT30M,PT30M,Mean evapotranspiration over the preceding 30 minutes in millimetres
+H2O_FLUX-MEAN_PREC-MMOLM-2S-1-PT30M-PT30M,,H2O_FLUX,MMOLM-2S-1,MEAN,PREC,PT30M,PT30M,Mean H2O flux over the preceding 30 minutes in millimoles per metre squared per second
+HEATFLUX_LATENT-MEAN_PREC-WM-2-PT30M-PT30M,,HEATFLUX_LATENT,WM-2,MEAN,PREC,PT30M,PT30M,Mean latent heat flux over the preceding 30 minutes in watts per metre squared
 HEATFLUX_SOIL-MEAN_PREC-WM-2-PT15M-PT15M,,HEATFLUX_SOIL,WM-2,MEAN,PREC,PT15M,PT15M,Mean soil heat flux in watts per metre squared over preceding 15 minutes
 HEIGHT_CANOPY-INST-M-PT30M-PT30M,,HEIGHT_CANOPY,M,NONE,INST,PT30M,PT30M,Instantaneous canopy height in metres
 HEIGHT_MEASUREMENT-INST-M-PT30M-PT30M,,HEIGHT_MEASUREMENT,M,NONE,INST,PT30M,PT30M,Instantaneous measurement height in metres
-QC_FLUX_MOM-INST-UNITLESS-PT30M-PT30M,,QC_FLUX_MOM,UNITLESS,NONE,INST,PT30M,PT30M,Instantaneous quality flag for momentum flux (unitless)
-QC_HEATFLUX_SENSIBLE-INST-UNITLESS-PT30M-PT30M,,QC_HEATFLUX_SENSIBLE,UNITLESS,NONE,INST,PT30M,PT30M,Instantaneous quality flag for sensible heat flux (unitless)
+QC_FLUX_MOM-MEAN_PREC-UNITLESS-PT30M-PT30M,,QC_FLUX_MOM,UNITLESS,MEAN,PREC,PT30M,PT30M,Quality flag for momentum flux over the preceding 30 minutes (unitless)
+QC_HEATFLUX_SENSIBLE-MEAN_PREC-UNITLESS-PT30M-PT30M,,QC_HEATFLUX_SENSIBLE,UNITLESS,MEAN,PREC,PT30M,PT30M,Quality flag for sensible heat flux over the preceding 30 minutes (unitless)
 SONIC_AZIMUTH-INST-DEG-PT30M-PT30M,,SONIC_AZIMUTH,DEG,NONE,INST,PT30M,PT30M,Instantaneous sonic anemometer azimuth angle in degrees
 TEMP_NR-MEAN_PREC-DEGC-PT1M-PT1M,,TEMP_NR,DEGC,MEAN,PREC,PT1M,PT1M,Mean net radiometer temperature over preceding minute in degrees Celsius
 TEMP_NR-MEAN_PREC-DEGC-PT30M-PT30M,,TEMP_NR,DEGC,MEAN,PREC,PT30M,PT30M,Mean net radiometer temperature over preceding 30 minutes in degrees Celsius
-UX_VAR-INST-M2S-2-PT30M-PT30M,,UX_VAR,M2S-2,NONE,INST,PT30M,PT30M,Instantaneous X component wind speed variance in metres squared per second squared
-UY_VAR-INST-M2S-2-PT30M-PT30M,,UY_VAR,M2S-2,NONE,INST,PT30M,PT30M,Instantaneous Y component wind speed variance in metres squared per second squared
-UZ_VAR-INST-M2S-2-PT30M-PT30M,,UZ_VAR,M2S-2,NONE,INST,PT30M,PT30M,Instantaneous Z component wind speed variance in metres squared per second squared
-VPD-INST-HPA-PT30M-PT30M,,VPD,HPA,NONE,INST,PT30M,PT30M,Instantaneous vapour pressure deficit in hectopascals
+UX_VAR-MEAN_PREC-M2S-2-PT30M-PT30M,,UX_VAR,M2S-2,MEAN,PREC,PT30M,PT30M,X component wind speed variance over the preceding 30 minutes in metres squared per second squared
+UY_VAR-MEAN_PREC-M2S-2-PT30M-PT30M,,UY_VAR,M2S-2,MEAN,PREC,PT30M,PT30M,Y component wind speed variance over the preceding 30 minutes in metres squared per second squared
+UZ_VAR-MEAN_PREC-M2S-2-PT30M-PT30M,,UZ_VAR,M2S-2,MEAN,PREC,PT30M,PT30M,Z component wind speed variance over the preceding 30 minutes in metres squared per second squared
+VPD-MEAN_PREC-HPA-PT30M-PT30M,,VPD,HPA,MEAN,PREC,PT30M,PT30M,Mean vapour pressure deficit over the preceding 30 minutes in hectopascals
 NEUTRON_COUNT-MEAN_PROC-CTS-S-1-PT1H-PT1H,,NEUTRON_COUNT,CTS-S-1,MEAN,PROC,PT1H,PT1H,Mean neutron count over the proceeding hour in counts per second

--- a/sample_data/src/flux/datasets.json
+++ b/sample_data/src/flux/datasets.json
@@ -298,7 +298,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "HEATFLUX_SENSIBLE-INST-WM-2-PT30M-PT30M"
+      "measure_id": "HEATFLUX_SENSIBLE-MEAN_PREC-WM-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-tau",
@@ -313,7 +313,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "FLUX_MOM-INST-KGM-1S-2-PT30M-PT30M"
+      "measure_id": "FLUX_MOM-MEAN_PREC-KGM-1S-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-co2-flux",
@@ -328,7 +328,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "CO2_FLUX-INST-UMOLM-2S-1-PT30M-PT30M"
+      "measure_id": "CO2_FLUX-MEAN_PREC-UMOLM-2S-1-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-h2o-flux",
@@ -343,7 +343,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "H2O_FLUX-INST-MMOLM-2S-1-PT30M-PT30M"
+      "measure_id": "H2O_FLUX-MEAN_PREC-MMOLM-2S-1-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-qc-h",
@@ -358,7 +358,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "QC_HEATFLUX_SENSIBLE-INST-UNITLESS-PT30M-PT30M"
+      "measure_id": "QC_HEATFLUX_SENSIBLE-MEAN_PREC-UNITLESS-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-qc-tau",
@@ -373,7 +373,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "QC_FLUX_MOM-INST-UNITLESS-PT30M-PT30M"
+      "measure_id": "QC_FLUX_MOM-MEAN_PREC-UNITLESS-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-wind-speed",
@@ -418,7 +418,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "VPD-INST-HPA-PT30M-PT30M"
+      "measure_id": "VPD-MEAN_PREC-HPA-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-sonic-temp",
@@ -433,7 +433,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "TEMP_SONIC-INST-DEGC-PT30M-PT30M"
+      "measure_id": "TEMP_SONIC-MEAN_PREC-DEGC-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-u-var",
@@ -448,7 +448,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "UX_VAR-INST-M2S-2-PT30M-PT30M"
+      "measure_id": "UX_VAR-MEAN_PREC-M2S-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-v-var",
@@ -463,7 +463,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "UY_VAR-INST-M2S-2-PT30M-PT30M"
+      "measure_id": "UY_VAR-MEAN_PREC-M2S-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-w-var",
@@ -478,7 +478,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "UZ_VAR-INST-M2S-2-PT30M-PT30M"
+      "measure_id": "UZ_VAR-MEAN_PREC-M2S-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-h-despiked",
@@ -493,7 +493,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "HEATFLUX_SENSIBLE-INST-WM-2-PT30M-PT30M"
+      "measure_id": "HEATFLUX_SENSIBLE-MEAN_PREC-WM-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-h-l2",
@@ -508,7 +508,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "HEATFLUX_SENSIBLE-INST-WM-2-PT30M-PT30M"
+      "measure_id": "HEATFLUX_SENSIBLE-MEAN_PREC-WM-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-tau-l2",
@@ -523,7 +523,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "FLUX_MOM-INST-KGM-1S-2-PT30M-PT30M"
+      "measure_id": "FLUX_MOM-MEAN_PREC-KGM-1S-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-shf",
@@ -553,7 +553,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "HEATFLUX_LATENT-INST-WM-2-PT30M-PT30M"
+      "measure_id": "HEATFLUX_LATENT-MEAN_PREC-WM-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-et-l1",
@@ -568,7 +568,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "ET-INST-MM-PT30M-PT30M"
+      "measure_id": "ET-MEAN_PREC-MM-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-le-l2",
@@ -583,7 +583,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "HEATFLUX_LATENT-INST-WM-2-PT30M-PT30M"
+      "measure_id": "HEATFLUX_LATENT-MEAN_PREC-WM-2-PT30M-PT30M"
     },
     {
       "dataset_id": "http://fdri.ceh.ac.uk/id/dataset/flux-plynl-et-l2",
@@ -598,7 +598,7 @@
       "resolution": "PT30M",
       "periodicity": "PT30M",
       "processing_level": "processed",
-      "measure_id": "ET-INST-MM-PT30M-PT30M"
+      "measure_id": "ET-MEAN_PREC-MM-PT30M-PT30M"
     }
   ]
 }


### PR DESCRIPTION
EddyPro timestamps each output row at the end of the averaging period, 
so PREC is the correct time anchor (not INST). The outputs are also 
30-minute means, not instantaneous values, so MEAN is the correct aggregation