### PR TITLE
Move /id/sensor/x to /id/system/x

### DIFF
--- a/sample_data/templates/fdri_asset_loc_history.yaml
+++ b/sample_data/templates/fdri_asset_loc_history.yaml
@@ -14,6 +14,6 @@ resources:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/deployment/fdri-{Site|slug}-{Platform|slug}-{locHistory_AssetID|slug}>"
       "@type": "<fdri:StaticDeployment>"
-      "<ssn:deployedSystem>": "<http://fdri.ceh.ac.uk/id/sensor/fdri-{locHistory_AssetID|slug}>"
+      "<ssn:deployedSystem>": "<http://fdri.ceh.ac.uk/id/system/fdri-{locHistory_AssetID|slug}>"
       "<ssn:deployedOnPlatform>": "<http://fdri.ceh.ac.uk/id/platform/fdri-{Site|slug}-{Platform|slug}>"
       "<prov:startedAtTime>": "{locHistory_Date|asDateTime}"

--- a/sample_data/templates/fdri_measure_ext.yaml
+++ b/sample_data/templates/fdri_measure_ext.yaml
@@ -10,7 +10,7 @@ imports:
 resources:
   - name: Sensor
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/fdri-{measure_AssetID|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/fdri-{measure_AssetID|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
 
   - name: Variable

--- a/sample_data/templates/fdri_site_assets.yaml
+++ b/sample_data/templates/fdri_site_assets.yaml
@@ -34,7 +34,7 @@ resources:
 
   - name: Sensor
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/fdri-{ID|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/fdri-{ID|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSystem>"
       "<dct:type>": <::SensorModel>
       "<rdfs:label>": "{asset_Name}@en"

--- a/sample_data/templates/flowstick_surveys.yaml
+++ b/sample_data/templates/flowstick_surveys.yaml
@@ -36,27 +36,27 @@ resources:
 
   - name: SensorFirmwareConfiguration
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/{system_type|slug}-{serial_number|slug}#firmware>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/{system_type|slug}-{serial_number|slug}#firmware>"
       "@type": "<fdri:ConfigurationValueSeries>"
       "<rdfs:label>": "Firmware configuration for {system_type} {serial_number}@en"
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/common/configuration-property/firmware-version>"
       "<fdri:hadValue>":
         - name: FirmwareVersion
           properties:
-            "@id": "<http://fdri.ceh.ac.uk/id/sensor/{system_type|slug}-{serial_number|slug}#firmware-version-{datetime|slug}>"
+            "@id": "<http://fdri.ceh.ac.uk/id/system/{system_type|slug}-{serial_number|slug}#firmware-version-{datetime|slug}>"
             "@type": "<fdri:TimeBoundPropertyValue>"
             "<rdfs:label>": "Firmware version for {system_type} {serial_number}@en"
             "<schema:value>": "{version}"
             "<fdri:interval>":
               - name: FirmwareVersionPeriod
                 properties:
-                  "@id": "<http://fdri.ceh.ac.uk/id/sensor/{system_type|slug}-{serial_number|slug}#firmware-version-{datetime|slug}.interval>"
+                  "@id": "<http://fdri.ceh.ac.uk/id/system/{system_type|slug}-{serial_number|slug}#firmware-version-{datetime|slug}.interval>"
                   "@type": "<dct:PeriodOfTime>"
                   "<dcat:startDate>": "{stime}^^<xsd:dateTime>"
                   "<dcat:endDate>": "{datetime}^^<xsd:dateTime>"
   - name: Sensor
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/{system_type|slug}-{serial_number|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/{system_type|slug}-{serial_number|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
       "<rdfs:label>": "{system_type} {serial_number}@en"
       "<fdri:serialNumber>": "{serial_number}"

--- a/sample_data/templates/rca_surveys.yaml
+++ b/sample_data/templates/rca_surveys.yaml
@@ -60,7 +60,7 @@ resources:
 
   - name: Impeller
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/rca-impeller-{Impeller no.|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/rca-impeller-{Impeller no.|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
       "<dct:type>": <::ImpellerType>
       "<sosa:observes>": <http://fdri.ceh.ac.uk/ref/common/cop/revolutions>

--- a/sample_data/templates/sensor_deployments.yaml
+++ b/sample_data/templates/sensor_deployments.yaml
@@ -18,7 +18,7 @@ resources:
       INSTRUMENT_ID:
       SERIAL_NUMBER:
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
       "<rdfs:label>": "{INSTRUMENT_ID} {SERIAL_NUMBER}@en"
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
@@ -29,9 +29,9 @@ resources:
       INSTRUMENT_ID:
       SERIAL_NUMBER:
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/deployment/cosmos-{SITE_ID|slug}-{COLUMN_NAME|slug}-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{INSTANCE|asInt}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/deployment/cosmos-{SITE_ID|slug}-{COLUMN_GROUP|slug}-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{INSTANCE|asInt}>"
       "@type": "<fdri:StaticDeployment>"
-      "<rdfs:label>": "Deployment of {INSTRUMENT_ID} {SERIAL_NUMBER} to {COLUMN_NAME} at {SITE_ID}@en"
+      "<rdfs:label>": "Deployment of {INSTRUMENT_ID} {SERIAL_NUMBER} to {COLUMN_GROUP} at {SITE_ID}@en"
       "<ssn:deployedSystem>": "<::Sensor>"
       "<ssn:deployedOnPlatform>": "<http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}>"
       "<prov:startedAtTime>": "{START_DATETIME|asDateTime}"
@@ -43,7 +43,7 @@ resources:
       SERIAL_NUMBER:
       END_DATETIME:
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/deployment/cosmos-{SITE_ID|slug}-{COLUMN_NAME|slug}-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{INSTANCE|asInt}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/deployment/cosmos-{SITE_ID|slug}-{COLUMN_GROUP|slug}-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}-{INSTANCE|asInt}>"
       "<prov:endedAtTime>": "{END_DATETIME|asDateTime}"
 
   - name: SensorDeploymentComments

--- a/sample_data/templates/sensor_faults.yaml
+++ b/sample_data/templates/sensor_faults.yaml
@@ -24,7 +24,7 @@ resources:
           "@type": "<dct:PeriodOfTime>"
           "<dcat:startDate>": "{START_DATETIME|asDateTime}"
           "<dcat:endDate>": "{END_DATETIME|asDateTime}"
-      "<fdri:affectedFacility>": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
+      "<fdri:affectedFacility>": "<http://fdri.ceh.ac.uk/id/system/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
 
   - name: StationFault
     requires:

--- a/sample_data/templates/sensor_firmware_configurations.yaml
+++ b/sample_data/templates/sensor_firmware_configurations.yaml
@@ -12,7 +12,7 @@ resources:
       INSTRUMENT_ID:
       SERIAL_NUMBER:
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
 
   - name: SensorFirmwareConfigurationSeries

--- a/sample_data/templates/sontek_surveys.yaml
+++ b/sample_data/templates/sontek_surveys.yaml
@@ -66,35 +66,35 @@ resources:
 
   - name: ADVConfiguration
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/sontek-adv-{ADV_Serial_Number|slug}#firmware-configuration>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/sontek-adv-{ADV_Serial_Number|slug}#firmware-configuration>"
       "@type": "<fdri:ConfigurationValueSeries>"
       "<rdfs:label>": "Firmware Version Configuration for Sontek ADV {ADV_Serial_Number}@en"
       "<dct:type>": <http://fdri.ceh.ac.uk/ref/common/configuration-property/firmware-version>
       "<fdri:hadValue>":
         - name: ConfigurationValue
           properties:
-            "@id": "<http://fdri.ceh.ac.uk/id/sensor/sontek-adv-{ADV_Serial_Number|slug}#firmware-configuration.value-{Date|slug}>"
+            "@id": "<http://fdri.ceh.ac.uk/id/system/sontek-adv-{ADV_Serial_Number|slug}#firmware-configuration.value-{Date|slug}>"
             "@type": "<fdri:TimeBoundPropertyValue>"
             "<fdri:interval>": <::SurveyInterval>
             "<schema:value>": "{ADV_Firmware_Version}"
 
   - name: ADVBeamsConfiguration
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/sontek-adv-{ADV_Serial_Number|slug}#beams-configuration>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/sontek-adv-{ADV_Serial_Number|slug}#beams-configuration>"
       "@type": "<fdri:ConfigurationValueSeries>"
       "<rdfs:label>": "Number of Beams Configuration for Sontek ADV {ADV_Serial_Number}@en"
       "<dct:type>": <http://fdri.ceh.ac.uk/ref/common/configuration-property/number-of-beams>
       "<fdri:hadValue>":
         - name: ConfigurationValue
           properties:
-            "@id": "<http://fdri.ceh.ac.uk/id/sensor/sontek-adv-{ADV_Serial_Number|slug}#beams-configuration.value-{Date|slug}>"
+            "@id": "<http://fdri.ceh.ac.uk/id/system/sontek-adv-{ADV_Serial_Number|slug}#beams-configuration.value-{Date|slug}>"
             "@type": "<fdri:TimeBoundPropertyValue>"
             "<fdri:interval>": <::SurveyInterval>
             "<schema:value>": "{ADV_NumberOfBeams}"
 
   - name: ADVDevice
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/id/sensor/sontek-adv-{ADV_Serial_Number|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/id/system/sontek-adv-{ADV_Serial_Number|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
       "<rdfs:label>": "Sontek ADV Device {ADV_Serial_Number}@en"
       "<dct:type>": <::SontekADVDeviceType>


### PR DESCRIPTION
This PR changes the identifiers for all sensors from /id/sensor/x to /id/system/x so that all systems and sensors have an identifier in the same namespace. This change makes it easier to map v2 data api endpoints as well as making it somewhat easier to construct references for deployments. 