### PR TITLE
Move all EMSystem types under a common controlled list

### DIFF
--- a/sample_data/templates/INSTRUMENTATION.yaml
+++ b/sample_data/templates/INSTRUMENTATION.yaml
@@ -6,26 +6,20 @@ imports:
   - namespaces.yaml
   - extensions.py
 
-one_offs:
-  - name: SystemTypeScheme
-    properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type>"
-      "@type": "<fdri:EnvironmentalMonitoringFacilityTypeScheme>"
-
 resources:
   - name: InstrumentType
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/ref/common/monitoring-system-type/{INSTRUMENT_ID|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSystemType>"
       "<skos:prefLabel>": "{INSTRUMENT_NAME}@en"
-      "<skos:inScheme>": "<::SystemTypeScheme>"
-      "^<skos:hasTopConcept>": "<::SystemTypeScheme>"
+      "<skos:inScheme>": "<::CommonSystemTypeScheme>"
+      "^<skos:hasTopConcept>": "<::CommonSystemTypeScheme>"
 
   - name: InstrumentDescription
     requires:
       INSTRUMENT_COMMENT:
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/ref/common/monitoring-system-type/{INSTRUMENT_ID|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSystemType>"
       "<skos:scopeNote>": "{INSTRUMENT_COMMENT}@en"
   
@@ -33,9 +27,9 @@ resources:
     requires:
       MODEL:
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{MODEL|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/ref/common/monitoring-system-type/{MODEL|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSystemType>"
       "<skos:prefLabel>": "{MODEL}@en"
-      "<skos:inScheme>": "<::SystemTypeScheme>"
+      "<skos:inScheme>": "<::CommonSystemTypeScheme>"
       "<skos:broader>": "<::InstrumentType>"
       "^<skos:narrower>": "<::InstrumentType>"

--- a/sample_data/templates/fdri_site_assets.yaml
+++ b/sample_data/templates/fdri_site_assets.yaml
@@ -7,14 +7,6 @@ imports:
     - concept_schemes.yaml
     - extensions.py
 
-one_offs:
-  - name: FdriSystemTypeScheme
-    properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/fdri/monitoring-system-type>"
-      "@type": "<fdri:EnvironmentalMonitoringFacilityTypeScheme>"
-      "<rdfs:label>": "FDRI Monitoring System Type Scheme@en"
-      "<dct:title>": "FDRI Monitoring System Type Scheme@en"
-
 resources:
   - name: Platform
     properties:
@@ -26,11 +18,11 @@ resources:
       asset_Make:
       asset_Model:
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/fdri/monitoring-system-type/{asset_Make|slug}-{asset_Model|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/ref/common/monitoring-system-type/{asset_Make|slug}-{asset_Model|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSystemType>"
       "<rdfs:label>": "{asset_Make} {asset_Model}@en"
-      "<skos:inScheme>": <::FdriSystemTypeScheme>
-      "^<skos:hasTopConcept>": <::FdriSystemTypeScheme>
+      "<skos:inScheme>": "<::CommonSystemTypeScheme>"
+      "^<skos:hasTopConcept>": "<::CommonSystemTypeScheme>"
 
   - name: Sensor
     properties:

--- a/sample_data/templates/flowstick_surveys.yaml
+++ b/sample_data/templates/flowstick_surveys.yaml
@@ -28,8 +28,8 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/ref/common/monitoring-system-type/{system_type|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringFacilityType>"
       "<skos:prefLabel>": "{system_type}@en"
-      "<skos:inScheme>": "<::SensorTypeScheme>"
-      "^<skos:hasTopConcept>": "<::SensorTypeScheme>"
+      "<skos:inScheme>": "<::CommonSystemTypeScheme>"
+      "^<skos:hasTopConcept>": "<::CommonSystemTypeScheme>"
       "<fdri:measures>":
         - <http://fdri.ceh.ac.uk/ref/common/measure/water_velocity-inst-ms-1>
         - <http://fdri.ceh.ac.uk/ref/common/measure/water_temp-inst-degc>

--- a/sample_data/templates/instrumentation_parameters.yaml
+++ b/sample_data/templates/instrumentation_parameters.yaml
@@ -6,20 +6,13 @@ imports:
   - namespaces.yaml
   - extensions.py
 
-one_offs:
-  - name: SystemTypeScheme
-    properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type>"
-      "@type": "<fdri:EnvironmentalMonitoringSystemTypeScheme>"
-      "<dct:title>": "COSMOS Monitoring System Types@en"
-
 resources:
 
   - name: IntrumentType
     properties:
-      "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
+      "@id": "<http://fdri.ceh.ac.uk/ref/common/monitoring-system-type/{INSTRUMENT_ID|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSystemType>"
       "<skos:prefLabel>": "{INSTRUMENT_ID}@en"
-      "<skos:inScheme>": "<::SystemTypeScheme>"
-      "^<skos:hasTopConcept>": "<::SystemTypeScheme>"
+      "<skos:inScheme>": "<::CommonSystemTypeScheme>"
+      "^<skos:hasTopConcept>": "<::CommonSystemTypeScheme>"
       "<sosa:observes>": "<http://fdri.ceh.ac.uk/ref/common/cop/{PARAMETER_ID|slug}>"

--- a/sample_data/templates/sensor_deployments.yaml
+++ b/sample_data/templates/sensor_deployments.yaml
@@ -13,6 +13,15 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}>"
       "@type": <fdri:GeospatialFeatureOfInterest>
 
+  - name: SensorType
+    properties:
+      "@id": "<http://fdri.ceh.ac.uk/ref/common/monitoring-system-type/{INSTRUMENT_ID|slug}>"
+      "@type": "<fdri:EnvironmentalMonitoringSystemType>"
+      "<skos:prefLabel>": "{INSTRUMENT_ID}@en"
+      "<skos:inScheme>": "<::CommonSystemTypeScheme>"
+      "^<skos:hasTopConcept>": "<::CommonSystemTypeScheme>"
+      "<sosa:observes>": "<http://fdri.ceh.ac.uk/ref/common/cop/{PARAMETER_ID|slug}>"
+
   - name: Sensor
     requires:
       INSTRUMENT_ID:
@@ -21,7 +30,7 @@ resources:
       "@id": "<http://fdri.ceh.ac.uk/id/system/cosmos-{INSTRUMENT_ID|slug}-{SERIAL_NUMBER|slug}>"
       "@type": "<fdri:EnvironmentalMonitoringSensor>"
       "<rdfs:label>": "{INSTRUMENT_ID} {SERIAL_NUMBER}@en"
-      "<dct:type>": "<http://fdri.ceh.ac.uk/ref/cosmos/monitoring-system-type/{INSTRUMENT_ID|slug}>"
+      "<dct:type>": "<::SensorType>"
       "<fdri:serialNumber>": "{SERIAL_NUMBER}"
 
   - name: SensorDeployment


### PR DESCRIPTION
We previously had separate controlled lists of sensor/system types for each network, but it makes more sense for there to be one controlled list of all sensor/system types referenced in DRI data so that commonalities across programmes can be more easily identified, and so that the current flat list can be later manually curated to be grouped by broader system type categories (e.g. radiometer, rain guage etc.)

This PR updates the templates so that all monitoring system and monitoring sensor types are placed in a single common vocabulary.