### PR TITLE
Fix the URI of the Facility Group Type concept scheme

### DIFF
--- a/sample_data/templates/concept_schemes.yaml
+++ b/sample_data/templates/concept_schemes.yaml
@@ -50,8 +50,8 @@ one_offs:
 
   - name: FacilityGroupTypeScheme
     properties:
-      "@id": <http://fdri.ceh.ac.uk/ref/group-type>
-      "@type": <fdri:FacilityGroupTypeScheme>
+      "@id": "<http://fdri.ceh.ac.uk/ref/common/group-type>"
+      "@type": "<fdri:FacilityGroupTypeScheme>"
       "<dct:title>": "Monitoring Facility Group Types@en"
       "<rdfs:label>": "Monitoring Facility Group Types@en"
 


### PR DESCRIPTION
Fixes #523 by changing the URI of the concept scheme from /ref/group-type to /ref/common/group-type to be consistent with the other concept schemes. This also means it will now display properly in the API