### PR TITLE
FPM-1204 - Update cosmos network label to COSMOS-UK

### DIFF
--- a/sample_data/templates/SITES_COSMOS.yaml
+++ b/sample_data/templates/SITES_COSMOS.yaml
@@ -12,25 +12,25 @@ one_offs:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/soil-type>"
       "@type": "<skos:ConceptScheme>"
-      "<dct:title>": "COSMOS Soil Type Classification Scheme@en"
+      "<dct:title>": "COSMOS-UK Soil Type Classification Scheme@en"
 
   - name: BedrockClassScheme
     properties:
       "@id": "<http://fdri.ceh.ac.uk/ref/cosmos/bedrock-class>"
       "@type": "<skos:ConceptScheme>"
-      "<dct:title>": "COSMOS Bedrock Classification Scheme@en"
+      "<dct:title>": "COSMOS-UK Bedrock Classification Scheme@en"
 
   - name: Cosmos
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/network/cosmos>"
       "@type": "<fdri:EnvironmentalMonitoringNetwork>"
-      "<rdfs:label>": "COSMOS Network@en"
+      "<rdfs:label>": "COSMOS-UK@en"
 
   - name: CosmosProgramme
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/programme/cosmos>"
       "@type": "<fdri:EnvironmentalMonitoringProgramme>"
-      "<rdfs:label>": "COSMOS Programme@en"
+      "<rdfs:label>": "COSMOS-UK Programme@en"
 
 resources:
     - name: MonitoredFeature
@@ -38,7 +38,7 @@ resources:
         "@id": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}>"
         "@type": "<fdri:GeospatialFeatureOfInterest>"
         "<rdfs:label>": "Environment at {SITE_NAME}@en"
-        "<geos:hasGeometry>": 
+        "<geos:hasGeometry>":
             - name: EastingsNorthingsPoint
               properties:
                 "@id": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}#geo-eastings>"
@@ -49,7 +49,7 @@ resources:
                 "@id": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}#geo-latlong>"
                 "@type": "<geos:Geometry>"
                 "<geos:asWKT>": "POINT({LONGITUDE} {LATITUDE})^^<geos:wktLiteral>"
-        "<fdri:hasRepresentativePoint>": 
+        "<fdri:hasRepresentativePoint>":
             - name: LatLongRepPoint
               properties:
                 "@id": "<http://fdri.ceh.ac.uk/id/feature/cosmos-{SITE_ID|slug}#point-latlong>"
@@ -79,7 +79,7 @@ resources:
         "^<doo:contains>": <::Cosmos>
         "^<doo:utilises>": <::CosmosProgramme>
         "<fdri:utilisedBy>": <::CosmosProgramme>
-        "<geos:hasGeometry>": 
+        "<geos:hasGeometry>":
             - name: EastingsNorthingsPoint
               properties:
                 "@id": "<http://fdri.ceh.ac.uk/id/site/cosmos-{SITE_ID|slug}#geo-eastings>"

--- a/sample_data/templates/SITES_NMDB.yaml
+++ b/sample_data/templates/SITES_NMDB.yaml
@@ -12,7 +12,7 @@ one_offs:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/network/nmdb>"
       "@type": "<fdri:EnvironmentalMonitoringNetwork>"
-      "<rdfs:label>": "NMDB Network@en"
+      "<rdfs:label>": "NMDB@en"
       "<foaf:homepage>": "https://www.nmdb.eu/station/^^<xsd:anyURI>"
 
   - name: Programme
@@ -48,4 +48,3 @@ resources:
             "@id": "<http://fdri.ceh.ac.uk/id/site/nmdb-{SITE_ID|slug}#operating-period>"
             "@type": "<dct:PeriodOfTime>"
             "<dcat:startDate>": "{DATE_INSTALLED | asDateOrDatetime}"
-

--- a/sample_data/templates/SITES_NRFA.yaml
+++ b/sample_data/templates/SITES_NRFA.yaml
@@ -12,7 +12,7 @@ one_offs:
     properties:
       "@id": "<http://fdri.ceh.ac.uk/id/network/nrfa>"
       "@type": "<fdri:EnvironmentalMonitoringNetwork>"
-      "<rdfs:label>": "NRFA Network@en"
+      "<rdfs:label>": "NRFA@en"
 
   - name: NrfaProgramme
     properties:
@@ -180,4 +180,3 @@ resources:
       "<rdfs:label>": "{COUNTRY_CODE}@en"
       "<dct:type>": "<http://fdri.ceh.ac.uk/ref/common/facility-group-type/country>"
       "<fdri:hasMember>": <::MonitoringSite>
-


### PR DESCRIPTION
# https://jira.ceh.ac.uk/browse/FPM-1204

Updates label in COSMOS network endpoint to be "COSMOS-UK" so that downstream, the data-api and UI can use this for display. 

Also removes 'network' from the NMDB and NRFA network labels. 

All other network's labels seem fine to be displayed as-is. 