### PR TITLE
542 use old site ids

### DIFF
--- a/sample_data/src/SITES_FDRI.csv
+++ b/sample_data/src/SITES_FDRI.csv
@@ -1,5 +1,5 @@
 Network,Catchment,Site_name,SiteAreaID,SiteID,Site_type,Latitude,Longitude,Date_installed,Date_decomissioned,Standard_installation,Description,Land_management
 FDRI,Severn,Carreg Wen,SE-CARWE-01,SE-CARWE-01,WS,52.48277697,-3.726718138,23-06-2025 12:00:00,,1,,Broadleaf woodland
-FDRI,Severn,Hafren Forest - Severn Trap,SE-SVTRP-01,SE-SVTRP-01-WL,WL,52.47060072,-3.69043706,19-05-2025 17:00:00,,0,Trapezoidal flume,
+FDRI,Severn,Hafren Forest - Severn Trap,SE-SVTRP-01,SE-HAFRF-07,WL,52.47060072,-3.69043706,19-05-2025 17:00:00,,0,Trapezoidal flume,
 FDRI,Severn,Foel Fadian,SE-FOFAD-01,SE-FOFAD-01-PR,PR,52.54511083,-3.720864236,03-12-2025 15:30:00,,1,,
 FDRI,,Test Site,,xx-UKCEH_Wallingford,TEST,51.603,-0.711,01-01-2024 00:00:00,,1,,

--- a/sample_data/src/SITES_FDRI.csv
+++ b/sample_data/src/SITES_FDRI.csv
@@ -1,5 +1,5 @@
 Network,Catchment,Site_name,SiteAreaID,SiteID,Site_type,Latitude,Longitude,Date_installed,Date_decomissioned,Standard_installation,Description,Land_management
-FDRI,Severn,Carreg Wen,SE-CARWE-01,SE-CARWE-01-WS,WS,52.48277697,-3.726718138,23-06-2025 12:00:00,,1,,Broadleaf woodland
+FDRI,Severn,Carreg Wen,SE-CARWE-01,SE-CARWE-01,WS,52.48277697,-3.726718138,23-06-2025 12:00:00,,1,,Broadleaf woodland
 FDRI,Severn,Hafren Forest - Severn Trap,SE-SVTRP-01,SE-SVTRP-01-WL,WL,52.47060072,-3.69043706,19-05-2025 17:00:00,,0,Trapezoidal flume,
 FDRI,Severn,Foel Fadian,SE-FOFAD-01,SE-FOFAD-01-PR,PR,52.54511083,-3.720864236,03-12-2025 15:30:00,,1,,
 FDRI,,Test Site,,xx-UKCEH_Wallingford,TEST,51.603,-0.711,01-01-2024 00:00:00,,1,,

--- a/sample_data/src/TIMESERIES_IDS_FDRI.csv
+++ b/sample_data/src/TIMESERIES_IDS_FDRI.csv
@@ -88,13 +88,13 @@ FDRI-SE-FOFAD-01-PR-TEMP_SOIL_4_15MIN_RAW,Soil temperature (50cm depth),SE-FOFAD
 FDRI-SE-FOFAD-01-PR-PERIOD_4_15MIN_RAW,Period (50cm depth),SE-FOFAD-01-PR,ukceh-dri-staging-ingested,fifteen_minute,CS655_4_P,time,PROP_PERIOD-MEAN_PREC-UNITLESS-PT15M-PT15M,RAW,
 FDRI-SE-FOFAD-01-PR-PERIOD_AVG_4_15MIN_RAW,Average period (50cm depth),SE-FOFAD-01-PR,ukceh-dri-staging-ingested,fifteen_minute,CS655_4_PA,time,PROP_PERIOD-MEAN_PREC-SEC-PT15M-PT15M,RAW,
 FDRI-SE-FOFAD-01-PR-VOLTAGE_RATIO_4_15MIN_RAW,Voltage ratio (50cm depth),SE-FOFAD-01-PR,ukceh-dri-staging-ingested,fifteen_minute,CS655_4_VR,time,VOLTAGE_RATIO-MEAN_PREC-UNITLESS-PT15M-PT15M,RAW,
-FDRI-SE-SVTRP-01-WL-BATTV_1MIN_RAW,Battery voltage,SE-SVTRP-01-WL,ukceh-dri-staging-ingested,one_minute,BattV,time,VOLTAGE_BATT-MEAN_PREC-V-PT1M-PT1M,RAW,
-FDRI-SE-SVTRP-01-WL-LOGGER_TEMP_1MIN_RAW,Temperature in the logger,SE-SVTRP-01-WL,ukceh-dri-staging-ingested,one_minute,PTemp_C,time,TEMP_LOGGER-INST-DEGC-PT1M-PT1M,RAW,
-FDRI-SE-SVTRP-01-WL-WATER_LEV_PT_1MIN_RAW,Water level (Pressure transducer),SE-SVTRP-01-WL,ukceh-dri-staging-ingested,one_minute,Lvl_cm_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,RAW,
-FDRI-SE-SVTRP-01-WL-WATER_LEV_RADAR_1MIN_RAW,Water level (Radar),SE-SVTRP-01-WL,ukceh-dri-staging-ingested,one_minute,Stage_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,RAW,
-FDRI-SE-SVTRP-01-WL-WATER_TEMP_1MIN_RAW,Water temperature (Pressure transducer),SE-SVTRP-01-WL,ukceh-dri-staging-ingested,one_minute,Temp_C_Avg,time,WATER_TEMP-INST-DEGC-PT1M-PT1M,RAW,
-FDRI-SE-SVTRP-01-WL-DIST_TO_WATER_RADAR_1MIN_RAW,Distance to water (Radar),SE-SVTRP-01-WL,ukceh-dri-staging-ingested,one_minute,Distance_m_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,RAW,
-FDRI-SE-SVTRP-01-WL-RADAR_TEMP_1MIN_RAW,Sensor temperature (Radar),SE-SVTRP-01-WL,ukceh-dri-staging-ingested,one_minute,Inst_Temp,time,TEMP_SENSOR-INST-DEGC-PT1M-PT1M,RAW,
+FDRI-SE-SVTRP-01-WL-BATTV_1MIN_RAW,Battery voltage,SE-HAFRF-07,ukceh-dri-staging-ingested,one_minute,BattV,time,VOLTAGE_BATT-MEAN_PREC-V-PT1M-PT1M,RAW,
+FDRI-SE-SVTRP-01-WL-LOGGER_TEMP_1MIN_RAW,Temperature in the logger,SE-HAFRF-07,ukceh-dri-staging-ingested,one_minute,PTemp_C,time,TEMP_LOGGER-INST-DEGC-PT1M-PT1M,RAW,
+FDRI-SE-SVTRP-01-WL-WATER_LEV_PT_1MIN_RAW,Water level (Pressure transducer),SE-HAFRF-07,ukceh-dri-staging-ingested,one_minute,Lvl_cm_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,RAW,
+FDRI-SE-SVTRP-01-WL-WATER_LEV_RADAR_1MIN_RAW,Water level (Radar),SE-HAFRF-07,ukceh-dri-staging-ingested,one_minute,Stage_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,RAW,
+FDRI-SE-SVTRP-01-WL-WATER_TEMP_1MIN_RAW,Water temperature (Pressure transducer),SE-HAFRF-07,ukceh-dri-staging-ingested,one_minute,Temp_C_Avg,time,WATER_TEMP-INST-DEGC-PT1M-PT1M,RAW,
+FDRI-SE-SVTRP-01-WL-DIST_TO_WATER_RADAR_1MIN_RAW,Distance to water (Radar),SE-HAFRF-07,ukceh-dri-staging-ingested,one_minute,Distance_m_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,RAW,
+FDRI-SE-SVTRP-01-WL-RADAR_TEMP_1MIN_RAW,Sensor temperature (Radar),SE-HAFRF-07,ukceh-dri-staging-ingested,one_minute,Inst_Temp,time,TEMP_SENSOR-INST-DEGC-PT1M-PT1M,RAW,
 FDRI-WALLING_TEST-SWIN_1MIN_RAW,Incoming shortwave radiation,WALLING_TEST,ukceh-dri-staging-ingested,thirty_minute,SWIN,time,SWIN-MEAN_PREC-WM-2-PT30M-PT30M,RAW,
 FDRI-WALLING_TEST-LWIN_1MIN_RAW,Incoming longwave radiation,WALLING_TEST,ukceh-dri-staging-ingested,thirty_minute,LWIN,time,LWIN-MEAN_PREC-WM-2-PT30M-PT30M,RAW,
 FDRI-WALLING_TEST-SWOUT_1MIN_RAW,Outgoing shortwave radiation,WALLING_TEST,ukceh-dri-staging-ingested,thirty_minute,SWOUT,time,SWOUT-MEAN_PREC-WM-2-PT30M-PT30M,RAW,
@@ -119,8 +119,8 @@ FDRI-SE-CARWE-01-WS-TA_1MIN_PROCESSED,Air temperature,SE-CARWE-01,ukceh-fdri-sta
 FDRI-SE-CARWE-01-WS-TNR01_1MIN_PROCESSED,Sensor temperature (NR01),SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,T_nr,time,TEMP_SENSOR-INST-KEL-PT1M-PT1M,PROCESSED,TNR01_FLAG_DEF
 FDRI-SE-CARWE-01-WS-WD_1MIN_PROCESSED,Wind direction,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,WindDir,time,WD-MEAN_PREC-DEG-PT1M-PT1M,PROCESSED,WD_FLAG_DEF
 FDRI-SE-CARWE-01-WS-WS_1MIN_PROCESSED,Wind speed,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,WS_ms_Avg,time,WS-MEAN_PREC-MS-1-PT1M-PT1M,PROCESSED,WS_FLAG_DEF
-FDRI-SE-SVTRP-01-WL-DIST_TO_WATER_RADAR_1MIN_PROCESSED,Distance to water (Radar),SE-SVTRP-01-WL,ukceh-fdri-staging-timeseries-processed,one_minute,Distance_m_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,PROCESSED,DIST_TO_WATER_RADAR_FLAG_DEF
-FDRI-SE-SVTRP-01-WL-RADAR_TEMP_1MIN_PROCESSED,Sensor temperature (Radar),SE-SVTRP-01-WL,ukceh-fdri-staging-timeseries-processed,one_minute,Inst_Temp,time,TEMP_SENSOR-INST-DEGC-PT1M-PT1M,PROCESSED,RADAR_TEMP_FLAG_DEF
-FDRI-SE-SVTRP-01-WL-WATER_LEV_PT_1MIN_PROCESSED,Water level (Pressure transducer),SE-SVTRP-01-WL,ukceh-fdri-staging-timeseries-processed,one_minute,Lvl_cm_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,PROCESSED,WATER_LEV_PT_FLAG_DEF
-FDRI-SE-SVTRP-01-WL-WATER_LEV_RADAR_1MIN_PROCESSED,Water level (Radar),SE-SVTRP-01-WL,ukceh-fdri-staging-timeseries-processed,one_minute,Stage_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,PROCESSED,WATER_LEV_RADAR_FLAG_DEF
-FDRI-SE-SVTRP-01-WL-WATER_TEMP_1MIN_PROCESSED,Water temperature (Pressure transducer),SE-SVTRP-01-WL,ukceh-fdri-staging-timeseries-processed,one_minute,Temp_C_Avg,time,WATER_TEMP-INST-DEGC-PT1M-PT1M,PROCESSED,WATER_TEMP_FLAG_DEF
+FDRI-SE-SVTRP-01-WL-DIST_TO_WATER_RADAR_1MIN_PROCESSED,Distance to water (Radar),SE-HAFRF-07,ukceh-fdri-staging-timeseries-processed,one_minute,Distance_m_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,PROCESSED,DIST_TO_WATER_RADAR_FLAG_DEF
+FDRI-SE-SVTRP-01-WL-RADAR_TEMP_1MIN_PROCESSED,Sensor temperature (Radar),SE-HAFRF-07,ukceh-fdri-staging-timeseries-processed,one_minute,Inst_Temp,time,TEMP_SENSOR-INST-DEGC-PT1M-PT1M,PROCESSED,RADAR_TEMP_FLAG_DEF
+FDRI-SE-SVTRP-01-WL-WATER_LEV_PT_1MIN_PROCESSED,Water level (Pressure transducer),SE-HAFRF-07,ukceh-fdri-staging-timeseries-processed,one_minute,Lvl_cm_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,PROCESSED,WATER_LEV_PT_FLAG_DEF
+FDRI-SE-SVTRP-01-WL-WATER_LEV_RADAR_1MIN_PROCESSED,Water level (Radar),SE-HAFRF-07,ukceh-fdri-staging-timeseries-processed,one_minute,Stage_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,PROCESSED,WATER_LEV_RADAR_FLAG_DEF
+FDRI-SE-SVTRP-01-WL-WATER_TEMP_1MIN_PROCESSED,Water temperature (Pressure transducer),SE-HAFRF-07,ukceh-fdri-staging-timeseries-processed,one_minute,Temp_C_Avg,time,WATER_TEMP-INST-DEGC-PT1M-PT1M,PROCESSED,WATER_TEMP_FLAG_DEF

--- a/sample_data/src/TIMESERIES_IDS_FDRI.csv
+++ b/sample_data/src/TIMESERIES_IDS_FDRI.csv
@@ -1,26 +1,26 @@
 TIMESERIES_ID,LABEL,SITE_ID,S3_BUCKET,S3_DATASET,COLUMN_NAME,TIME_COLUMN_NAME,MEASURE_ID,PROCESS_LEVEL,FLAG_DEF
-FDRI-SE-CARWE-01-WS-BATTV_1MIN_RAW,Battery voltage,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,BattV_Avg,time,VOLTAGE_BATT-MEAN_PREC-V-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-BATTSOC_1MIN_RAW,Battery state of charge,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,BattSoC_Avg,time,SOC_BATT-MEAN_PREC-PCT-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-RH_1MIN_RAW,Relative humidity,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,RH,time,RH-MEAN_PREC-PCT-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-WD_1MIN_RAW,Wind direction,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,WindDir,time,WD-MEAN_PREC-DEG-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-WS_1MIN_RAW,Wind speed,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,WS_ms_Avg,time,WS-MEAN_PREC-MS-1-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-PRECIP_INT_1MIN_RAW,Precipitation intensity,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,RainE_Int_1m,time,PRECIP_INTEN-MEAN_PREC-MM_M-1-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-PRECIP_INT_HR_1MIN_RAW,Precipitation intensity,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,RainE_Int_1m_hr,time,PRECIP_INTEN-MEAN_PREC-MM_HR-1-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-PRECIP_INT_LR_1MIN_RAW,Precipitation intensity since last request,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,RainE_Int_lr,time,PRECIP_INTEN_LR-MEAN_PREC-MM_M-1-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-PRECIP_INT_LR_HR_1MIN_RAW,Precipitation intensity since last request,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,RainE_Int_lr_hr,time,PRECIP_INTEN_LR-MEAN_PREC-MM_HR-1-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-PRECIP_1MIN_RAW,Precipitation,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,RainE_Precip_lr,time,PRECIP-TOTAL_PREC-MM-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-PRECIP_TOT_1MIN_RAW,Accumulated total precipitation,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,RainE_Precip_Tot,time,PRECIP_TOT-TOTAL_PREC-MM-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-PA_1MIN_RAW,Atmospheric pressure,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,Pressure_Avg,time,PA-MEAN_PREC-HPA-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-ALBEDO_1MIN_RAW,Albedo,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,albedo_Avg,time,ALBEDO-MEAN_PREC-UNITLESS-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-SWIN_1MIN_RAW,Incoming shortwave radiation,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,R_SW_in_Avg,time,SWIN-MEAN_PREC-WM-2-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-SWOUT_1MIN_RAW,Outgoing shortwave radiation,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,R_SW_out_Avg,time,SWOUT-MEAN_PREC-WM-2-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-LWIN_1MIN_RAW,Incoming longwave radiation,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,R_LW_in_Avg,time,LWIN-MEAN_PREC-WM-2-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-LWOUT_1MIN_RAW,Outgoing longwave radiation,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,R_LW_out_Avg,time,LWOUT-MEAN_PREC-WM-2-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-TNR01_1MIN_RAW,Sensor temperature (NR01),SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,T_nr,time,TEMP_SENSOR-INST-KEL-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-TNR01_AVG_1MIN_RAW,Sensor temperature (NR01),SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,T_nr_Avg,time,TEMP_SENSOR-MEAN_PREC-KEL-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-TA_1MIN_RAW,Air temperature,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,AirTemp_C,time,TEMP_AIR-MEAN_PREC-DEGC-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-DEWPOINT_1MIN_RAW,Dew point temperature,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,DewPoint_C,time,DEW_POINT-INST-DEGC-PT1M-PT1M,RAW,
-FDRI-SE-CARWE-01-WS-TS100_FAN_RPM_1MIN_RAW,Aspirated screen fan speed,SE-CARWE-01-WS,ukceh-dri-staging-ingested,one_minute,TS100SS_Fan_RPM,time,REVOLUTIONS-MEAN_PREC-RPM-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-BATTV_1MIN_RAW,Battery voltage,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,BattV_Avg,time,VOLTAGE_BATT-MEAN_PREC-V-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-BATTSOC_1MIN_RAW,Battery state of charge,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,BattSoC_Avg,time,SOC_BATT-MEAN_PREC-PCT-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-RH_1MIN_RAW,Relative humidity,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,RH,time,RH-MEAN_PREC-PCT-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-WD_1MIN_RAW,Wind direction,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,WindDir,time,WD-MEAN_PREC-DEG-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-WS_1MIN_RAW,Wind speed,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,WS_ms_Avg,time,WS-MEAN_PREC-MS-1-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-PRECIP_INT_1MIN_RAW,Precipitation intensity,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,RainE_Int_1m,time,PRECIP_INTEN-MEAN_PREC-MM_M-1-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-PRECIP_INT_HR_1MIN_RAW,Precipitation intensity,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,RainE_Int_1m_hr,time,PRECIP_INTEN-MEAN_PREC-MM_HR-1-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-PRECIP_INT_LR_1MIN_RAW,Precipitation intensity since last request,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,RainE_Int_lr,time,PRECIP_INTEN_LR-MEAN_PREC-MM_M-1-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-PRECIP_INT_LR_HR_1MIN_RAW,Precipitation intensity since last request,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,RainE_Int_lr_hr,time,PRECIP_INTEN_LR-MEAN_PREC-MM_HR-1-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-PRECIP_1MIN_RAW,Precipitation,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,RainE_Precip_lr,time,PRECIP-TOTAL_PREC-MM-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-PRECIP_TOT_1MIN_RAW,Accumulated total precipitation,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,RainE_Precip_Tot,time,PRECIP_TOT-TOTAL_PREC-MM-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-PA_1MIN_RAW,Atmospheric pressure,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,Pressure_Avg,time,PA-MEAN_PREC-HPA-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-ALBEDO_1MIN_RAW,Albedo,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,albedo_Avg,time,ALBEDO-MEAN_PREC-UNITLESS-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-SWIN_1MIN_RAW,Incoming shortwave radiation,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,R_SW_in_Avg,time,SWIN-MEAN_PREC-WM-2-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-SWOUT_1MIN_RAW,Outgoing shortwave radiation,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,R_SW_out_Avg,time,SWOUT-MEAN_PREC-WM-2-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-LWIN_1MIN_RAW,Incoming longwave radiation,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,R_LW_in_Avg,time,LWIN-MEAN_PREC-WM-2-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-LWOUT_1MIN_RAW,Outgoing longwave radiation,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,R_LW_out_Avg,time,LWOUT-MEAN_PREC-WM-2-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-TNR01_1MIN_RAW,Sensor temperature (NR01),SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,T_nr,time,TEMP_SENSOR-INST-KEL-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-TNR01_AVG_1MIN_RAW,Sensor temperature (NR01),SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,T_nr_Avg,time,TEMP_SENSOR-MEAN_PREC-KEL-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-TA_1MIN_RAW,Air temperature,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,AirTemp_C,time,TEMP_AIR-MEAN_PREC-DEGC-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-DEWPOINT_1MIN_RAW,Dew point temperature,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,DewPoint_C,time,DEW_POINT-INST-DEGC-PT1M-PT1M,RAW,
+FDRI-SE-CARWE-01-WS-TS100_FAN_RPM_1MIN_RAW,Aspirated screen fan speed,SE-CARWE-01,ukceh-dri-staging-ingested,one_minute,TS100SS_Fan_RPM,time,REVOLUTIONS-MEAN_PREC-RPM-PT1M-PT1M,RAW,
 FDRI-SE-FOFAD-01-PR-BATTV_1MIN_RAW,Battery voltage,SE-FOFAD-01-PR,ukceh-dri-staging-ingested,one_minute,BattV,time,VOLTAGE_BATT-MEAN_PREC-V-PT1M-PT1M,RAW,
 FDRI-SE-FOFAD-01-PR-WD_1MIN_RAW,Wind direction,SE-FOFAD-01-PR,ukceh-dri-staging-ingested,one_minute,WindDir,time,WD-MEAN_PREC-DEG-PT1M-PT1M,RAW,
 FDRI-SE-FOFAD-01-PR-WS_1MIN_RAW,Wind speed,SE-FOFAD-01-PR,ukceh-dri-staging-ingested,one_minute,Windspeed,time,WS-MEAN_PREC-MS-1-PT1M-PT1M,RAW,
@@ -100,25 +100,25 @@ FDRI-WALLING_TEST-LWIN_1MIN_RAW,Incoming longwave radiation,WALLING_TEST,ukceh-d
 FDRI-WALLING_TEST-SWOUT_1MIN_RAW,Outgoing shortwave radiation,WALLING_TEST,ukceh-dri-staging-ingested,thirty_minute,SWOUT,time,SWOUT-MEAN_PREC-WM-2-PT30M-PT30M,RAW,
 FDRI-WALLING_TEST-LWOUT_1MIN_RAW,Outgoing longwave radiation,WALLING_TEST,ukceh-dri-staging-ingested,thirty_minute,LWOUT,time,LWOUT-MEAN_PREC-WM-2-PT30M-PT30M,RAW,
 FDRI-WALLING_TEST-TNR01_AVG_1MIN_RAW,Sensor temperature (NR01),WALLING_TEST,ukceh-dri-staging-ingested,thirty_minute,TNR01,time,TEMP_SENSOR-MEAN_PREC-KEL-PT30M-PT30M,RAW,
-FDRI-SE-CARWE-01-WS-ALBEDO_1MIN_PROCESSED,Albedo,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,albedo_Avg,time,ALBEDO-MEAN_PREC-UNITLESS-PT1M-PT1M,PROCESSED,ALBEDO_FLAG_DEF
-FDRI-SE-CARWE-01-WS-DEWPOINT_1MIN_PROCESSED,Dew point temperature,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,DewPoint_C,time,DEW_POINT-INST-DEGC-PT1M-PT1M,PROCESSED,DEWPOINT_FLAG_DEF
-FDRI-SE-CARWE-01-WS-PRECIP_INT_1MIN_PROCESSED,Precipitation intensity,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Int_1m,time,PRECIP_INTEN-MEAN_PREC-MM_M-1-PT1M-PT1M,PROCESSED,PRECIP_INT_FLAG_DEF
-FDRI-SE-CARWE-01-WS-PRECIP_INT_HR_1MIN_PROCESSED,Precipitation intensity,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Int_1m_hr,time,PRECIP_INTEN-MEAN_PREC-MM_HR-1-PT1M-PT1M,PROCESSED,PRECIP_INT_HR_FLAG_DEF
-FDRI-SE-CARWE-01-WS-PRECIP_INT_LR_1MIN_PROCESSED,Precipitation intensity since last request,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Int_lr,time,PRECIP_INTEN_LR-MEAN_PREC-MM_M-1-PT1M-PT1M,PROCESSED,PRECIP_INT_LR_FLAG_DEF
-FDRI-SE-CARWE-01-WS-PRECIP_INT_LR_HR_1MIN_PROCESSED,Precipitation intensity since last request,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Int_lr_hr,time,PRECIP_INTEN_LR-MEAN_PREC-MM_HR-1-PT1M-PT1M,PROCESSED,PRECIP_INT_LR_HR_FLAG_DEF
-FDRI-SE-CARWE-01-WS-LWIN_1MIN_PROCESSED,Incoming longwave radiation,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,R_LW_in_Avg,time,LWIN-MEAN_PREC-WM-2-PT1M-PT1M,PROCESSED,LWIN_FLAG_DEF
-FDRI-SE-CARWE-01-WS-LWOUT_1MIN_PROCESSED,Outgoing longwave radiation,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,R_LW_out_Avg,time,LWOUT-MEAN_PREC-WM-2-PT1M-PT1M,PROCESSED,LWOUT_FLAG_DEF
-FDRI-SE-CARWE-01-WS-PA_1MIN_PROCESSED,Atmospheric pressure,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,Pressure_Avg,time,PA-MEAN_PREC-HPA-PT1M-PT1M,PROCESSED,PA_FLAG_DEF
-FDRI-SE-CARWE-01-WS-PRECIP_1MIN_PROCESSED,Precipitation,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Precip_lr,time,PRECIP-TOTAL_PREC-MM-PT1M-PT1M,PROCESSED,PRECIP_FLAG_DEF
-FDRI-SE-CARWE-01-WS-PRECIP_TOT_1MIN_PROCESSED,Accumulated total precipitation,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Precip_Tot,time,PRECIP_TOT-TOTAL_PREC-MM-PT1M-PT1M,PROCESSED,PRECIP_TOT_FLAG_DEF
-FDRI-SE-CARWE-01-WS-RH_1MIN_PROCESSED,Relative humidity,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,RH,time,RH-MEAN_PREC-PCT-PT1M-PT1M,PROCESSED,RH_FLAG_DEF
-FDRI-SE-CARWE-01-WS-TNR01_AVG_1MIN_PROCESSED,Sensor temperature (NR01),SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,T_nr_Avg,time,TEMP_SENSOR-MEAN_PREC-KEL-PT1M-PT1M,PROCESSED,TNR01_FLAG_DEF
-FDRI-SE-CARWE-01-WS-SWIN_1MIN_PROCESSED,Incoming shortwave radiation,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,R_SW_in_Avg,time,SWIN-MEAN_PREC-WM-2-PT1M-PT1M,PROCESSED,SWIN_FLAG_DEF
-FDRI-SE-CARWE-01-WS-SWOUT_1MIN_PROCESSED,Outgoing shortwave radiation,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,R_SW_out_Avg,time,SWOUT-MEAN_PREC-WM-2-PT1M-PT1M,PROCESSED,SWOUT_FLAG_DEF
-FDRI-SE-CARWE-01-WS-TA_1MIN_PROCESSED,Air temperature,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,AirTemp_C,time,TEMP_AIR-MEAN_PREC-DEGC-PT1M-PT1M,PROCESSED,TA_FLAG_DEF
-FDRI-SE-CARWE-01-WS-TNR01_1MIN_PROCESSED,Sensor temperature (NR01),SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,T_nr,time,TEMP_SENSOR-INST-KEL-PT1M-PT1M,PROCESSED,TNR01_FLAG_DEF
-FDRI-SE-CARWE-01-WS-WD_1MIN_PROCESSED,Wind direction,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,WindDir,time,WD-MEAN_PREC-DEG-PT1M-PT1M,PROCESSED,WD_FLAG_DEF
-FDRI-SE-CARWE-01-WS-WS_1MIN_PROCESSED,Wind speed,SE-CARWE-01-WS,ukceh-fdri-staging-timeseries-processed,one_minute,WS_ms_Avg,time,WS-MEAN_PREC-MS-1-PT1M-PT1M,PROCESSED,WS_FLAG_DEF
+FDRI-SE-CARWE-01-WS-ALBEDO_1MIN_PROCESSED,Albedo,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,albedo_Avg,time,ALBEDO-MEAN_PREC-UNITLESS-PT1M-PT1M,PROCESSED,ALBEDO_FLAG_DEF
+FDRI-SE-CARWE-01-WS-DEWPOINT_1MIN_PROCESSED,Dew point temperature,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,DewPoint_C,time,DEW_POINT-INST-DEGC-PT1M-PT1M,PROCESSED,DEWPOINT_FLAG_DEF
+FDRI-SE-CARWE-01-WS-PRECIP_INT_1MIN_PROCESSED,Precipitation intensity,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Int_1m,time,PRECIP_INTEN-MEAN_PREC-MM_M-1-PT1M-PT1M,PROCESSED,PRECIP_INT_FLAG_DEF
+FDRI-SE-CARWE-01-WS-PRECIP_INT_HR_1MIN_PROCESSED,Precipitation intensity,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Int_1m_hr,time,PRECIP_INTEN-MEAN_PREC-MM_HR-1-PT1M-PT1M,PROCESSED,PRECIP_INT_HR_FLAG_DEF
+FDRI-SE-CARWE-01-WS-PRECIP_INT_LR_1MIN_PROCESSED,Precipitation intensity since last request,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Int_lr,time,PRECIP_INTEN_LR-MEAN_PREC-MM_M-1-PT1M-PT1M,PROCESSED,PRECIP_INT_LR_FLAG_DEF
+FDRI-SE-CARWE-01-WS-PRECIP_INT_LR_HR_1MIN_PROCESSED,Precipitation intensity since last request,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Int_lr_hr,time,PRECIP_INTEN_LR-MEAN_PREC-MM_HR-1-PT1M-PT1M,PROCESSED,PRECIP_INT_LR_HR_FLAG_DEF
+FDRI-SE-CARWE-01-WS-LWIN_1MIN_PROCESSED,Incoming longwave radiation,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,R_LW_in_Avg,time,LWIN-MEAN_PREC-WM-2-PT1M-PT1M,PROCESSED,LWIN_FLAG_DEF
+FDRI-SE-CARWE-01-WS-LWOUT_1MIN_PROCESSED,Outgoing longwave radiation,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,R_LW_out_Avg,time,LWOUT-MEAN_PREC-WM-2-PT1M-PT1M,PROCESSED,LWOUT_FLAG_DEF
+FDRI-SE-CARWE-01-WS-PA_1MIN_PROCESSED,Atmospheric pressure,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,Pressure_Avg,time,PA-MEAN_PREC-HPA-PT1M-PT1M,PROCESSED,PA_FLAG_DEF
+FDRI-SE-CARWE-01-WS-PRECIP_1MIN_PROCESSED,Precipitation,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Precip_lr,time,PRECIP-TOTAL_PREC-MM-PT1M-PT1M,PROCESSED,PRECIP_FLAG_DEF
+FDRI-SE-CARWE-01-WS-PRECIP_TOT_1MIN_PROCESSED,Accumulated total precipitation,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,RainE_Precip_Tot,time,PRECIP_TOT-TOTAL_PREC-MM-PT1M-PT1M,PROCESSED,PRECIP_TOT_FLAG_DEF
+FDRI-SE-CARWE-01-WS-RH_1MIN_PROCESSED,Relative humidity,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,RH,time,RH-MEAN_PREC-PCT-PT1M-PT1M,PROCESSED,RH_FLAG_DEF
+FDRI-SE-CARWE-01-WS-TNR01_AVG_1MIN_PROCESSED,Sensor temperature (NR01),SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,T_nr_Avg,time,TEMP_SENSOR-MEAN_PREC-KEL-PT1M-PT1M,PROCESSED,TNR01_FLAG_DEF
+FDRI-SE-CARWE-01-WS-SWIN_1MIN_PROCESSED,Incoming shortwave radiation,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,R_SW_in_Avg,time,SWIN-MEAN_PREC-WM-2-PT1M-PT1M,PROCESSED,SWIN_FLAG_DEF
+FDRI-SE-CARWE-01-WS-SWOUT_1MIN_PROCESSED,Outgoing shortwave radiation,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,R_SW_out_Avg,time,SWOUT-MEAN_PREC-WM-2-PT1M-PT1M,PROCESSED,SWOUT_FLAG_DEF
+FDRI-SE-CARWE-01-WS-TA_1MIN_PROCESSED,Air temperature,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,AirTemp_C,time,TEMP_AIR-MEAN_PREC-DEGC-PT1M-PT1M,PROCESSED,TA_FLAG_DEF
+FDRI-SE-CARWE-01-WS-TNR01_1MIN_PROCESSED,Sensor temperature (NR01),SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,T_nr,time,TEMP_SENSOR-INST-KEL-PT1M-PT1M,PROCESSED,TNR01_FLAG_DEF
+FDRI-SE-CARWE-01-WS-WD_1MIN_PROCESSED,Wind direction,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,WindDir,time,WD-MEAN_PREC-DEG-PT1M-PT1M,PROCESSED,WD_FLAG_DEF
+FDRI-SE-CARWE-01-WS-WS_1MIN_PROCESSED,Wind speed,SE-CARWE-01,ukceh-fdri-staging-timeseries-processed,one_minute,WS_ms_Avg,time,WS-MEAN_PREC-MS-1-PT1M-PT1M,PROCESSED,WS_FLAG_DEF
 FDRI-SE-SVTRP-01-WL-DIST_TO_WATER_RADAR_1MIN_PROCESSED,Distance to water (Radar),SE-SVTRP-01-WL,ukceh-fdri-staging-timeseries-processed,one_minute,Distance_m_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,PROCESSED,DIST_TO_WATER_RADAR_FLAG_DEF
 FDRI-SE-SVTRP-01-WL-RADAR_TEMP_1MIN_PROCESSED,Sensor temperature (Radar),SE-SVTRP-01-WL,ukceh-fdri-staging-timeseries-processed,one_minute,Inst_Temp,time,TEMP_SENSOR-INST-DEGC-PT1M-PT1M,PROCESSED,RADAR_TEMP_FLAG_DEF
 FDRI-SE-SVTRP-01-WL-WATER_LEV_PT_1MIN_PROCESSED,Water level (Pressure transducer),SE-SVTRP-01-WL,ukceh-fdri-staging-timeseries-processed,one_minute,Lvl_cm_Avg,time,WATER_LEVEL-INST-M-PT1M-PT1M,PROCESSED,WATER_LEV_PT_FLAG_DEF


### PR DESCRIPTION
Addresses https://github.com/NERC-CEH/fdri-discovery/issues/542

Change:
SE-CARWE-01-WS to SE-CARWE-01
SE-SVTRP-01-WL to SE-HAFRF-07

These the staion IDs being used in the S3 bucket