### PR TITLE
Update configuration id for precip int plan

### DIFF
--- a/sample_data/src/processing_plans_fdri.json
+++ b/sample_data/src/processing_plans_fdri.json
@@ -28,7 +28,7 @@
       "input": "FDRI-SE-CARWE-01-WS-PRECIP_INT_1MIN_RAW",
       "steps": [
         "fdri-se-carwe-01-ws-precip_int_1min-load_raw",
-        "fdri-se-carwe-01-ws-dewpoint_1min-battery_v",
+        "fdri-se-carwe-01-ws-precip_int_1min-battery_v",
         "fdri-se-carwe-01-ws-precip_int_1min-battery_v",
         "fdri-se-carwe-01-ws-precip_int_1min-range"
       ]


### PR DESCRIPTION
fdri-se-carwe-01-ws-**dewpoint**_1min-battery_v listed in the plan for fdri-se-carwe-01-ws-precip_int.

Updated to be fdri-se-carwe-01-ws-**precip_int**_1min-battery_v