### PR TITLE
FPM-689 - Update d86 configs

### DIFF
--- a/sample_data/src/processing_configurations_cosmos.json
+++ b/sample_data/src/processing_configurations_cosmos.json
@@ -692,7 +692,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ALIC1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -701,7 +702,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -718,7 +719,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ALIC1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -727,7 +729,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -744,7 +746,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ALIC1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -753,7 +756,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -770,7 +773,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ALIC1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -779,7 +783,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -796,7 +800,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ALIC1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -805,7 +810,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -822,7 +827,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ALIC1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -831,7 +837,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -848,7 +854,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ALIC1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -857,7 +864,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -874,7 +881,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ALIC1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -883,7 +891,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -900,7 +908,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ALIC1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -909,7 +918,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -926,7 +935,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ALIC1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -935,7 +945,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -952,7 +962,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ALIC1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -961,7 +972,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -978,7 +989,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ALIC1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ALIC1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -987,7 +999,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5787,7 +5799,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BALRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -5796,7 +5809,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5813,7 +5826,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BALRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -5822,7 +5836,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5839,7 +5853,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BALRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -5848,7 +5863,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5865,7 +5880,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BALRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -5874,7 +5890,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5891,7 +5907,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BALRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -5900,7 +5917,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5917,7 +5934,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BALRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -5926,7 +5944,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5943,7 +5961,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BALRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -5952,7 +5971,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5969,7 +5988,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BALRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -5978,7 +5998,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -5995,7 +6015,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BALRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -6004,7 +6025,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -6021,7 +6042,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BALRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -6030,7 +6052,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -6047,7 +6069,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BALRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -6056,7 +6079,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -6073,7 +6096,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BALRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BALRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -6082,7 +6106,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10720,7 +10744,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BICKL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -10729,7 +10754,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10746,7 +10771,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BICKL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -10755,7 +10781,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10772,7 +10798,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BICKL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -10781,7 +10808,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10798,7 +10825,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BICKL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -10807,7 +10835,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10824,7 +10852,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BICKL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -10833,7 +10862,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10850,7 +10879,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BICKL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -10859,7 +10889,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10876,7 +10906,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BICKL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -10885,7 +10916,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10902,7 +10933,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BICKL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -10911,7 +10943,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10928,7 +10960,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BICKL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -10937,7 +10970,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10954,7 +10987,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BICKL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -10963,7 +10997,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -10980,7 +11014,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BICKL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -10989,7 +11024,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -11006,7 +11041,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BICKL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BICKL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -11015,7 +11051,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15703,7 +15739,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BUNNY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -15712,7 +15749,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15729,7 +15766,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BUNNY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -15738,7 +15776,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15755,7 +15793,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BUNNY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -15764,7 +15803,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15781,7 +15820,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BUNNY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -15790,7 +15830,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15807,7 +15847,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BUNNY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -15816,7 +15857,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15833,7 +15874,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BUNNY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -15842,7 +15884,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15859,7 +15901,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BUNNY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -15868,7 +15911,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15885,7 +15928,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BUNNY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -15894,7 +15938,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15911,7 +15955,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BUNNY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -15920,7 +15965,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15937,7 +15982,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BUNNY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -15946,7 +15992,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15963,7 +16009,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-BUNNY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -15972,7 +16019,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -15989,7 +16036,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-BUNNY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-BUNNY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -15998,7 +16046,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20754,7 +20802,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CARDT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -20763,7 +20812,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20780,7 +20829,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CARDT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -20789,7 +20839,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20806,7 +20856,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CARDT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -20815,7 +20866,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20832,7 +20883,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CARDT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -20841,7 +20893,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20858,7 +20910,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CARDT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -20867,7 +20920,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20884,7 +20937,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CARDT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -20893,7 +20947,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20910,7 +20964,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CARDT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -20919,7 +20974,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20936,7 +20991,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CARDT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -20945,7 +21001,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20962,7 +21018,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CARDT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -20971,7 +21028,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -20988,7 +21045,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CARDT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -20997,7 +21055,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -21014,7 +21072,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CARDT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -21023,7 +21082,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -21040,7 +21099,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CARDT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CARDT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -21049,7 +21109,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26185,7 +26245,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CGARW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -26194,7 +26255,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26211,7 +26272,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CGARW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -26220,7 +26282,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26237,7 +26299,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CGARW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -26246,7 +26309,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26263,7 +26326,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CGARW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -26272,7 +26336,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26289,7 +26353,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CGARW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -26298,7 +26363,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26315,7 +26380,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CGARW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -26324,7 +26390,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26341,7 +26407,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CGARW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -26350,7 +26417,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26367,7 +26434,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CGARW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -26376,7 +26444,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26393,7 +26461,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CGARW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -26402,7 +26471,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26419,7 +26488,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CGARW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -26428,7 +26498,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26445,7 +26515,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CGARW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -26454,7 +26525,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -26471,7 +26542,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CGARW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CGARW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -26480,7 +26552,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34274,7 +34346,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHIMN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -34283,7 +34356,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34300,7 +34373,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHIMN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -34309,7 +34383,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34326,7 +34400,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHIMN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -34335,7 +34410,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34352,7 +34427,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHIMN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -34361,7 +34437,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34378,7 +34454,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHIMN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -34387,7 +34464,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34404,7 +34481,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHIMN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -34413,7 +34491,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34430,7 +34508,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHIMN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -34439,7 +34518,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34456,7 +34535,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHIMN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -34465,7 +34545,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34482,7 +34562,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHIMN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -34491,7 +34572,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34508,7 +34589,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHIMN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -34517,7 +34599,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34534,7 +34616,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHIMN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -34543,7 +34626,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -34560,7 +34643,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHIMN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHIMN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -34569,7 +34653,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41759,7 +41843,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHOBH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -41768,7 +41853,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41785,7 +41870,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHOBH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -41794,7 +41880,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41811,7 +41897,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHOBH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -41820,7 +41907,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41837,7 +41924,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHOBH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -41846,7 +41934,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41863,7 +41951,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHOBH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -41872,7 +41961,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41889,7 +41978,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHOBH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -41898,7 +41988,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41915,7 +42005,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHOBH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -41924,7 +42015,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41941,7 +42032,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHOBH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -41950,7 +42042,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41967,7 +42059,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHOBH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -41976,7 +42069,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -41993,7 +42086,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHOBH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -42002,7 +42096,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -42019,7 +42113,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CHOBH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -42028,7 +42123,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -42045,7 +42140,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CHOBH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CHOBH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -42054,7 +42150,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47205,7 +47301,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCHN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -47214,7 +47311,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47231,7 +47328,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCHN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -47240,7 +47338,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47257,7 +47355,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCHN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -47266,7 +47365,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47283,7 +47382,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCHN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -47292,7 +47392,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47309,7 +47409,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCHN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -47318,7 +47419,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47335,7 +47436,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCHN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -47344,7 +47446,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47361,7 +47463,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCHN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -47370,7 +47473,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47387,7 +47490,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCHN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -47396,7 +47500,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47413,7 +47517,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCHN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -47422,7 +47527,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47439,7 +47544,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCHN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -47448,7 +47554,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47465,7 +47571,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCHN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -47474,7 +47581,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -47491,7 +47598,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCHN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCHN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -47500,7 +47608,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -54930,7 +55038,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCLP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -54939,7 +55048,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -54956,7 +55065,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCLP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -54965,7 +55075,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -54982,7 +55092,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCLP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -54991,7 +55102,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55008,7 +55119,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCLP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -55017,7 +55129,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55034,7 +55146,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCLP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -55043,7 +55156,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55060,7 +55173,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCLP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -55069,7 +55183,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55086,7 +55200,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCLP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -55095,7 +55210,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55112,7 +55227,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCLP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -55121,7 +55237,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55138,7 +55254,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCLP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -55147,7 +55264,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55164,7 +55281,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCLP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -55173,7 +55291,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55190,7 +55308,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-COCLP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -55199,7 +55318,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -55216,7 +55335,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-COCLP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-COCLP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -55225,7 +55345,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -59848,7 +59968,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CRICH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -59857,7 +59978,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -59874,7 +59995,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CRICH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -59883,7 +60005,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -59900,7 +60022,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CRICH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -59909,7 +60032,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -59926,7 +60049,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CRICH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -59935,7 +60059,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -59952,7 +60076,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CRICH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -59961,7 +60086,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -59978,7 +60103,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CRICH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -59987,7 +60113,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -60004,7 +60130,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CRICH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -60013,7 +60140,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -60030,7 +60157,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CRICH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -60039,7 +60167,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -60056,7 +60184,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CRICH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -60065,7 +60194,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -60082,7 +60211,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CRICH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -60091,7 +60221,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -60108,7 +60238,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-CRICH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -60117,7 +60248,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -60134,7 +60265,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-CRICH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-CRICH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -60143,7 +60275,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -64982,7 +65114,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EASTB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -64991,7 +65124,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65008,7 +65141,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EASTB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -65017,7 +65151,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65034,7 +65168,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EASTB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -65043,7 +65178,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65060,7 +65195,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EASTB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -65069,7 +65205,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65086,7 +65222,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EASTB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -65095,7 +65232,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65112,7 +65249,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EASTB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -65121,7 +65259,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65138,7 +65276,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EASTB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -65147,7 +65286,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65164,7 +65303,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EASTB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -65173,7 +65313,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65190,7 +65330,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EASTB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -65199,7 +65340,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65216,7 +65357,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EASTB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -65225,7 +65367,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65242,7 +65384,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EASTB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -65251,7 +65394,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -65268,7 +65411,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EASTB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EASTB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -65277,7 +65421,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70350,7 +70494,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ELMST-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -70359,7 +70504,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70376,7 +70521,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ELMST-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -70385,7 +70531,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70402,7 +70548,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ELMST-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -70411,7 +70558,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70428,7 +70575,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ELMST-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -70437,7 +70585,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70454,7 +70602,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ELMST-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -70463,7 +70612,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70480,7 +70629,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ELMST-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -70489,7 +70639,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70506,7 +70656,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ELMST-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -70515,7 +70666,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70532,7 +70683,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ELMST-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -70541,7 +70693,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70558,7 +70710,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ELMST-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -70567,7 +70720,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70584,7 +70737,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ELMST-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -70593,7 +70747,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70610,7 +70764,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ELMST-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -70619,7 +70774,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -70636,7 +70791,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ELMST-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ELMST-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -70645,7 +70801,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -77975,7 +78131,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EUSTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -77984,7 +78141,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78001,7 +78158,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EUSTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -78010,7 +78168,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78027,7 +78185,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EUSTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -78036,7 +78195,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78053,7 +78212,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EUSTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -78062,7 +78222,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78079,7 +78239,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EUSTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -78088,7 +78249,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78105,7 +78266,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EUSTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -78114,7 +78276,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78131,7 +78293,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EUSTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -78140,7 +78303,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78157,7 +78320,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EUSTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -78166,7 +78330,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78183,7 +78347,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EUSTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -78192,7 +78357,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78209,7 +78374,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EUSTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -78218,7 +78384,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78235,7 +78401,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-EUSTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -78244,7 +78411,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -78261,7 +78428,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-EUSTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-EUSTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -78270,7 +78438,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85581,7 +85749,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FINCH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -85590,7 +85759,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85607,7 +85776,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FINCH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -85616,7 +85786,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85633,7 +85803,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FINCH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -85642,7 +85813,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85659,7 +85830,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FINCH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -85668,7 +85840,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85685,7 +85857,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FINCH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -85694,7 +85867,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85711,7 +85884,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FINCH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -85720,7 +85894,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85737,7 +85911,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FINCH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -85746,7 +85921,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85763,7 +85938,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FINCH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -85772,7 +85948,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85789,7 +85965,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FINCH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -85798,7 +85975,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85815,7 +85992,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FINCH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -85824,7 +86002,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85841,7 +86019,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FINCH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -85850,7 +86029,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -85867,7 +86046,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FINCH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FINCH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -85876,7 +86056,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93252,7 +93432,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FIVET-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -93261,7 +93442,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93278,7 +93459,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FIVET-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -93287,7 +93469,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93304,7 +93486,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FIVET-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -93313,7 +93496,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93330,7 +93513,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FIVET-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -93339,7 +93523,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93356,7 +93540,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FIVET-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -93365,7 +93550,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93382,7 +93567,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FIVET-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -93391,7 +93577,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93408,7 +93594,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FIVET-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -93417,7 +93604,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93434,7 +93621,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FIVET-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -93443,7 +93631,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93460,7 +93648,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FIVET-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -93469,7 +93658,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93486,7 +93675,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FIVET-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -93495,7 +93685,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93512,7 +93702,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-FIVET-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -93521,7 +93712,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -93538,7 +93729,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-FIVET-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-FIVET-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -93547,7 +93739,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -100942,7 +101134,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GISBN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -100951,7 +101144,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -100968,7 +101161,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GISBN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -100977,7 +101171,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -100994,7 +101188,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GISBN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -101003,7 +101198,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101020,7 +101215,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GISBN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -101029,7 +101225,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101046,7 +101242,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GISBN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -101055,7 +101252,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101072,7 +101269,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GISBN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -101081,7 +101279,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101098,7 +101296,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GISBN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -101107,7 +101306,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101124,7 +101323,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GISBN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -101133,7 +101333,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101150,7 +101350,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GISBN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -101159,7 +101360,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101176,7 +101377,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GISBN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -101185,7 +101387,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101202,7 +101404,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GISBN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -101211,7 +101414,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -101228,7 +101431,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GISBN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GISBN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -101237,7 +101441,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106309,7 +106513,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -106318,7 +106523,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106335,7 +106540,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -106344,7 +106550,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106361,7 +106567,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -106370,7 +106577,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106387,7 +106594,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -106396,7 +106604,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106413,7 +106621,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -106422,7 +106631,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106439,7 +106648,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -106448,7 +106658,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106465,7 +106675,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -106474,7 +106685,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106491,7 +106702,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -106500,7 +106712,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106517,7 +106729,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -106526,7 +106739,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106543,7 +106756,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -106552,7 +106766,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106569,7 +106783,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -106578,7 +106793,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -106595,7 +106810,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -106604,7 +106820,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111677,7 +111893,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -111686,7 +111903,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111703,7 +111920,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -111712,7 +111930,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111729,7 +111947,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -111738,7 +111957,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111755,7 +111974,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -111764,7 +111984,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111781,7 +112001,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -111790,7 +112011,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111807,7 +112028,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -111816,7 +112038,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111833,7 +112055,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -111842,7 +112065,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111859,7 +112082,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -111868,7 +112092,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111885,7 +112109,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -111894,7 +112119,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111911,7 +112136,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -111920,7 +112146,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111937,7 +112163,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-GLENW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -111946,7 +112173,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -111963,7 +112190,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-GLENW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-GLENW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -111972,7 +112200,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119463,7 +119691,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HADLW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -119472,7 +119701,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119489,7 +119718,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HADLW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -119498,7 +119728,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119515,7 +119745,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HADLW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -119524,7 +119755,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119541,7 +119772,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HADLW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -119550,7 +119782,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119567,7 +119799,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HADLW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -119576,7 +119809,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119593,7 +119826,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HADLW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -119602,7 +119836,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119619,7 +119853,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HADLW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -119628,7 +119863,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119645,7 +119880,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HADLW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -119654,7 +119890,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119671,7 +119907,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HADLW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -119680,7 +119917,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119697,7 +119934,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HADLW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -119706,7 +119944,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119723,7 +119961,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HADLW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -119732,7 +119971,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -119749,7 +119988,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HADLW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HADLW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -119758,7 +119998,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -126837,7 +127077,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARTW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -126846,7 +127087,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -126863,7 +127104,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARTW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -126872,7 +127114,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -126889,7 +127131,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARTW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -126898,7 +127141,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -126915,7 +127158,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARTW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -126924,7 +127168,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -126941,7 +127185,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARTW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -126950,7 +127195,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -126967,7 +127212,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARTW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -126976,7 +127222,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -126993,7 +127239,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARTW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -127002,7 +127249,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -127019,7 +127266,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARTW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -127028,7 +127276,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -127045,7 +127293,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARTW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -127054,7 +127303,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -127071,7 +127320,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARTW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -127080,7 +127330,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -127097,7 +127347,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARTW-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -127106,7 +127357,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -127123,7 +127374,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARTW-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARTW-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -127132,7 +127384,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131400,7 +131652,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARWD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -131409,7 +131662,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131426,7 +131679,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARWD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -131435,7 +131689,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131452,7 +131706,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARWD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -131461,7 +131716,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131478,7 +131733,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARWD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -131487,7 +131743,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131504,7 +131760,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARWD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -131513,7 +131770,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131530,7 +131787,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARWD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -131539,7 +131797,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131556,7 +131814,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARWD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -131565,7 +131824,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131582,7 +131841,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARWD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -131591,7 +131851,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131608,7 +131868,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARWD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -131617,7 +131878,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131634,7 +131895,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARWD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -131643,7 +131905,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131660,7 +131922,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HARWD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -131669,7 +131932,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -131686,7 +131949,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HARWD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HARWD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -131695,7 +131959,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -135975,7 +136239,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HENFS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -135984,7 +136249,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136001,7 +136266,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HENFS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -136010,7 +136276,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136027,7 +136293,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HENFS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -136036,7 +136303,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136053,7 +136320,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HENFS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -136062,7 +136330,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136079,7 +136347,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HENFS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -136088,7 +136357,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136105,7 +136374,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HENFS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -136114,7 +136384,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136131,7 +136401,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HENFS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -136140,7 +136411,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136157,7 +136428,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HENFS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -136166,7 +136438,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136183,7 +136455,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HENFS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -136192,7 +136465,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136209,7 +136482,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HENFS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -136218,7 +136492,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136235,7 +136509,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HENFS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -136244,7 +136519,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -136261,7 +136536,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HENFS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HENFS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -136270,7 +136546,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141125,7 +141401,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HILLB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -141134,7 +141411,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141151,7 +141428,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HILLB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -141160,7 +141438,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141177,7 +141455,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HILLB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -141186,7 +141465,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141203,7 +141482,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HILLB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -141212,7 +141492,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141229,7 +141509,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HILLB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -141238,7 +141519,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141255,7 +141536,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HILLB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -141264,7 +141546,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141281,7 +141563,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HILLB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -141290,7 +141573,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141307,7 +141590,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HILLB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -141316,7 +141600,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141333,7 +141617,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HILLB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -141342,7 +141627,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141359,7 +141644,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HILLB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -141368,7 +141654,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141385,7 +141671,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HILLB-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -141394,7 +141681,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -141411,7 +141698,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HILLB-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HILLB-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -141420,7 +141708,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148731,7 +149019,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HLACY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -148740,7 +149029,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148757,7 +149046,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HLACY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -148766,7 +149056,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148783,7 +149073,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HLACY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -148792,7 +149083,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148809,7 +149100,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HLACY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -148818,7 +149110,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148835,7 +149127,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HLACY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -148844,7 +149137,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148861,7 +149154,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HLACY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -148870,7 +149164,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148887,7 +149181,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HLACY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -148896,7 +149191,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148913,7 +149208,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HLACY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -148922,7 +149218,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148939,7 +149235,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HLACY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -148948,7 +149245,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148965,7 +149262,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HLACY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -148974,7 +149272,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -148991,7 +149289,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HLACY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -149000,7 +149299,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -149017,7 +149316,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HLACY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HLACY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -149026,7 +149326,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156303,7 +156603,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HOLLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -156312,7 +156613,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156329,7 +156630,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HOLLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -156338,7 +156640,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156355,7 +156657,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HOLLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -156364,7 +156667,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156381,7 +156684,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HOLLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -156390,7 +156694,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156407,7 +156711,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HOLLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -156416,7 +156721,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156433,7 +156738,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HOLLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -156442,7 +156748,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156459,7 +156765,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HOLLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -156468,7 +156775,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156485,7 +156792,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HOLLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -156494,7 +156802,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156511,7 +156819,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HOLLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -156520,7 +156829,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156537,7 +156846,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HOLLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -156546,7 +156856,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156563,7 +156873,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HOLLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -156572,7 +156883,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -156589,7 +156900,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HOLLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HOLLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -156598,7 +156910,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161746,7 +162058,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HYBRY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -161755,7 +162068,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161772,7 +162085,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HYBRY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -161781,7 +162095,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161798,7 +162112,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HYBRY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -161807,7 +162122,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161824,7 +162139,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HYBRY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -161833,7 +162149,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161850,7 +162166,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HYBRY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -161859,7 +162176,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161876,7 +162193,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HYBRY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -161885,7 +162203,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161902,7 +162220,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HYBRY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -161911,7 +162230,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161928,7 +162247,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HYBRY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -161937,7 +162257,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161954,7 +162274,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HYBRY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -161963,7 +162284,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -161980,7 +162301,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HYBRY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -161989,7 +162311,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -162006,7 +162328,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-HYBRY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -162015,7 +162338,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -162032,7 +162355,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-HYBRY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-HYBRY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -162041,7 +162365,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169120,7 +169444,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LIZRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -169129,7 +169454,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169146,7 +169471,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LIZRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -169155,7 +169481,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169172,7 +169498,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LIZRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -169181,7 +169508,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169198,7 +169525,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LIZRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -169207,7 +169535,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169224,7 +169552,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LIZRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -169233,7 +169562,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169250,7 +169579,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LIZRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -169259,7 +169589,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169276,7 +169606,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LIZRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -169285,7 +169616,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169302,7 +169633,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LIZRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -169311,7 +169643,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169328,7 +169660,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LIZRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -169337,7 +169670,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169354,7 +169687,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LIZRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -169363,7 +169697,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169380,7 +169714,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LIZRD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -169389,7 +169724,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -169406,7 +169741,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LIZRD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LIZRD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -169415,7 +169751,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174370,7 +174706,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LODTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -174379,7 +174716,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174396,7 +174733,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LODTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -174405,7 +174743,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174422,7 +174760,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LODTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -174431,7 +174770,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174448,7 +174787,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LODTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -174457,7 +174797,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174474,7 +174814,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LODTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -174483,7 +174824,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174500,7 +174841,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LODTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -174509,7 +174851,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174526,7 +174868,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LODTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -174535,7 +174878,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174552,7 +174895,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LODTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -174561,7 +174905,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174578,7 +174922,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LODTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -174587,7 +174932,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174604,7 +174949,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LODTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -174613,7 +174959,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174630,7 +174976,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LODTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -174639,7 +174986,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -174656,7 +175003,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LODTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LODTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -174665,7 +175013,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -181809,7 +182157,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LULLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -181818,7 +182167,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -181835,7 +182184,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LULLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -181844,7 +182194,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -181861,7 +182211,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LULLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -181870,7 +182221,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -181887,7 +182238,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LULLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -181896,7 +182248,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -181913,7 +182265,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LULLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -181922,7 +182275,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -181939,7 +182292,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LULLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -181948,7 +182302,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -181965,7 +182319,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LULLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -181974,7 +182329,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -181991,7 +182346,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LULLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -182000,7 +182356,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -182017,7 +182373,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LULLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -182026,7 +182383,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -182043,7 +182400,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LULLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -182052,7 +182410,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -182069,7 +182427,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-LULLN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -182078,7 +182437,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -182095,7 +182454,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-LULLN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-LULLN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -182104,7 +182464,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187023,7 +187383,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOORH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -187032,7 +187393,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187049,7 +187410,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOORH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -187058,7 +187420,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187075,7 +187437,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOORH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -187084,7 +187447,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187101,7 +187464,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOORH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -187110,7 +187474,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187127,7 +187491,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOORH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -187136,7 +187501,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187153,7 +187518,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOORH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -187162,7 +187528,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187179,7 +187545,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOORH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -187188,7 +187555,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187205,7 +187572,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOORH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -187214,7 +187582,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187231,7 +187599,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOORH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -187240,7 +187609,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187257,7 +187626,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOORH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -187266,7 +187636,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187283,7 +187653,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOORH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -187292,7 +187663,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -187309,7 +187680,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOORH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOORH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -187318,7 +187690,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192391,7 +192763,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOREM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -192400,7 +192773,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192417,7 +192790,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOREM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -192426,7 +192800,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192443,7 +192817,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOREM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -192452,7 +192827,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192469,7 +192844,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOREM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -192478,7 +192854,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192495,7 +192871,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOREM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -192504,7 +192881,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192521,7 +192898,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOREM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -192530,7 +192908,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192547,7 +192925,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOREM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -192556,7 +192935,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192573,7 +192952,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOREM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -192582,7 +192962,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192599,7 +192979,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOREM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -192608,7 +192989,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192625,7 +193006,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOREM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -192634,7 +193016,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192651,7 +193033,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MOREM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -192660,7 +193043,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -192677,7 +193060,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MOREM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MOREM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -192686,7 +193070,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -199830,7 +200214,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MORLY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -199839,7 +200224,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -199856,7 +200241,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MORLY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -199865,7 +200251,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -199882,7 +200268,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MORLY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -199891,7 +200278,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -199908,7 +200295,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MORLY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -199917,7 +200305,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -199934,7 +200322,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MORLY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -199943,7 +200332,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -199960,7 +200349,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MORLY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -199969,7 +200359,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -199986,7 +200376,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MORLY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -199995,7 +200386,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -200012,7 +200403,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MORLY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -200021,7 +200413,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -200038,7 +200430,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MORLY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -200047,7 +200440,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -200064,7 +200457,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MORLY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -200073,7 +200467,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -200090,7 +200484,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-MORLY-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -200099,7 +200494,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -200116,7 +200511,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-MORLY-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-MORLY-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -200125,7 +200521,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204748,7 +205144,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-NWYKE-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -204757,7 +205154,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204774,7 +205171,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-NWYKE-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -204783,7 +205181,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204800,7 +205198,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-NWYKE-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -204809,7 +205208,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204826,7 +205225,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-NWYKE-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -204835,7 +205235,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204852,7 +205252,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-NWYKE-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -204861,7 +205262,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204878,7 +205279,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-NWYKE-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -204887,7 +205289,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204904,7 +205306,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-NWYKE-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -204913,7 +205316,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204930,7 +205333,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-NWYKE-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -204939,7 +205343,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204956,7 +205360,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-NWYKE-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -204965,7 +205370,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -204982,7 +205387,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-NWYKE-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -204991,7 +205397,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -205008,7 +205414,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-NWYKE-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -205017,7 +205424,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -205034,7 +205441,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-NWYKE-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-NWYKE-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -205043,7 +205451,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -209882,7 +210290,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PLYNL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -209891,7 +210300,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -209908,7 +210317,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PLYNL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -209917,7 +210327,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -209934,7 +210344,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PLYNL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -209943,7 +210354,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -209960,7 +210371,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PLYNL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -209969,7 +210381,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -209986,7 +210398,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PLYNL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -209995,7 +210408,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -210012,7 +210425,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PLYNL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -210021,7 +210435,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -210038,7 +210452,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PLYNL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -210047,7 +210462,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -210064,7 +210479,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PLYNL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -210073,7 +210489,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -210090,7 +210506,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PLYNL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -210099,7 +210516,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -210116,7 +210533,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PLYNL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -210125,7 +210543,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -210142,7 +210560,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PLYNL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -210151,7 +210570,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -210168,7 +210587,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PLYNL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PLYNL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -210177,7 +210597,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215176,7 +215596,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PORTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -215185,7 +215606,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215202,7 +215623,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PORTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -215211,7 +215633,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215228,7 +215650,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PORTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -215237,7 +215660,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215254,7 +215677,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PORTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -215263,7 +215687,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215280,7 +215704,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PORTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -215289,7 +215714,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215306,7 +215731,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PORTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -215315,7 +215741,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215332,7 +215758,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PORTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -215341,7 +215768,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215358,7 +215785,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PORTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -215367,7 +215795,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215384,7 +215812,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PORTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -215393,7 +215822,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215410,7 +215839,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PORTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -215419,7 +215849,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215436,7 +215866,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-PORTN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -215445,7 +215876,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -215462,7 +215893,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-PORTN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-PORTN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -215471,7 +215903,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220109,7 +220541,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RDMER-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -220118,7 +220551,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220135,7 +220568,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RDMER-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -220144,7 +220578,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220161,7 +220595,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RDMER-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -220170,7 +220605,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220187,7 +220622,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RDMER-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -220196,7 +220632,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220213,7 +220649,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RDMER-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -220222,7 +220659,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220239,7 +220676,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RDMER-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -220248,7 +220686,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220265,7 +220703,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RDMER-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -220274,7 +220713,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220291,7 +220730,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RDMER-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -220300,7 +220740,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220317,7 +220757,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RDMER-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -220326,7 +220767,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220343,7 +220784,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RDMER-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -220352,7 +220794,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220369,7 +220811,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RDMER-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -220378,7 +220821,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -220395,7 +220838,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RDMER-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RDMER-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -220404,7 +220848,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225027,7 +225471,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-REDHL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -225036,7 +225481,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225053,7 +225498,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-REDHL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -225062,7 +225508,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225079,7 +225525,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-REDHL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -225088,7 +225535,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225105,7 +225552,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-REDHL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -225114,7 +225562,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225131,7 +225579,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-REDHL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -225140,7 +225589,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225157,7 +225606,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-REDHL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -225166,7 +225616,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225183,7 +225633,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-REDHL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -225192,7 +225643,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225209,7 +225660,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-REDHL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -225218,7 +225670,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225235,7 +225687,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-REDHL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -225244,7 +225697,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225261,7 +225714,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-REDHL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -225270,7 +225724,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225287,7 +225741,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-REDHL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -225296,7 +225751,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -225313,7 +225768,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-REDHL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-REDHL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -225322,7 +225778,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230242,7 +230698,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RISEH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -230251,7 +230708,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230268,7 +230725,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RISEH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -230277,7 +230735,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230294,7 +230752,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RISEH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -230303,7 +230762,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230320,7 +230779,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RISEH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -230329,7 +230789,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230346,7 +230806,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RISEH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -230355,7 +230816,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230372,7 +230833,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RISEH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -230381,7 +230843,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230398,7 +230860,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RISEH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -230407,7 +230870,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230424,7 +230887,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RISEH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -230433,7 +230897,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230450,7 +230914,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RISEH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -230459,7 +230924,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230476,7 +230941,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RISEH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -230485,7 +230951,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230502,7 +230968,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-RISEH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -230511,7 +230978,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -230528,7 +230995,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-RISEH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-RISEH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -230537,7 +231005,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237616,7 +238084,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ROTHD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -237625,7 +238094,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237642,7 +238111,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ROTHD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -237651,7 +238121,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237668,7 +238138,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ROTHD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -237677,7 +238148,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237694,7 +238165,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ROTHD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -237703,7 +238175,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237720,7 +238192,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ROTHD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -237729,7 +238202,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237746,7 +238219,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ROTHD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -237755,7 +238229,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237772,7 +238246,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ROTHD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -237781,7 +238256,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237798,7 +238273,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ROTHD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -237807,7 +238283,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237824,7 +238300,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ROTHD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -237833,7 +238310,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237850,7 +238327,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ROTHD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -237859,7 +238337,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237876,7 +238354,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-ROTHD-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -237885,7 +238364,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -237902,7 +238381,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-ROTHD-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-ROTHD-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -237911,7 +238391,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243111,7 +243591,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SHEEP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -243120,7 +243601,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243137,7 +243618,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SHEEP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -243146,7 +243628,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243163,7 +243645,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SHEEP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -243172,7 +243655,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243189,7 +243672,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SHEEP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -243198,7 +243682,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243215,7 +243699,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SHEEP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -243224,7 +243709,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243241,7 +243726,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SHEEP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -243250,7 +243736,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243267,7 +243753,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SHEEP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -243276,7 +243763,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243293,7 +243780,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SHEEP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -243302,7 +243790,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243319,7 +243807,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SHEEP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -243328,7 +243817,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243345,7 +243834,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SHEEP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -243354,7 +243844,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243371,7 +243861,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SHEEP-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -243380,7 +243871,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -243397,7 +243888,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SHEEP-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SHEEP-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -243406,7 +243898,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -250865,7 +251357,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SOURH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -250874,7 +251367,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -250891,7 +251384,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SOURH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -250900,7 +251394,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -250917,7 +251411,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SOURH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -250926,7 +251421,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -250943,7 +251438,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SOURH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -250952,7 +251448,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -250969,7 +251465,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SOURH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -250978,7 +251475,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -250995,7 +251492,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SOURH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -251004,7 +251502,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -251021,7 +251519,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SOURH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -251030,7 +251529,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -251047,7 +251546,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SOURH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -251056,7 +251556,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -251073,7 +251573,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SOURH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -251082,7 +251583,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -251099,7 +251600,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SOURH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -251108,7 +251610,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -251125,7 +251627,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SOURH-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -251134,7 +251637,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -251151,7 +251654,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SOURH-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SOURH-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -251160,7 +251664,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256233,7 +256737,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SPENF-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -256242,7 +256747,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256259,7 +256764,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SPENF-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -256268,7 +256774,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256285,7 +256791,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SPENF-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -256294,7 +256801,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256311,7 +256818,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SPENF-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -256320,7 +256828,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256337,7 +256845,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SPENF-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -256346,7 +256855,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256363,7 +256872,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SPENF-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -256372,7 +256882,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256389,7 +256899,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SPENF-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -256398,7 +256909,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256415,7 +256926,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SPENF-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -256424,7 +256936,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256441,7 +256953,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SPENF-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -256450,7 +256963,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256467,7 +256980,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SPENF-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -256476,7 +256990,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256493,7 +257007,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SPENF-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -256502,7 +257017,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -256519,7 +257034,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SPENF-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SPENF-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -256528,7 +257044,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263756,7 +264272,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STGHT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -263765,7 +264282,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263782,7 +264299,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STGHT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -263791,7 +264309,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263808,7 +264326,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STGHT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -263817,7 +264336,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263834,7 +264353,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STGHT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -263843,7 +264363,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263860,7 +264380,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STGHT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -263869,7 +264390,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263886,7 +264407,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STGHT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -263895,7 +264417,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263912,7 +264434,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STGHT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -263921,7 +264444,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263938,7 +264461,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STGHT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -263947,7 +264471,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263964,7 +264488,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STGHT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -263973,7 +264498,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -263990,7 +264515,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STGHT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -263999,7 +264525,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -264016,7 +264542,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STGHT-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -264025,7 +264552,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -264042,7 +264569,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STGHT-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STGHT-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -264051,7 +264579,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -268857,7 +269385,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STIPS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -268866,7 +269395,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -268883,7 +269412,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STIPS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -268892,7 +269422,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -268909,7 +269439,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STIPS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -268918,7 +269449,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -268935,7 +269466,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STIPS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -268944,7 +269476,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -268961,7 +269493,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STIPS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -268970,7 +269503,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -268987,7 +269520,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STIPS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -268996,7 +269530,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -269013,7 +269547,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STIPS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -269022,7 +269557,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -269039,7 +269574,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STIPS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -269048,7 +269584,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -269065,7 +269601,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STIPS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -269074,7 +269611,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -269091,7 +269628,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STIPS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -269100,7 +269638,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -269117,7 +269655,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-STIPS-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -269126,7 +269665,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -269143,7 +269682,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-STIPS-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-STIPS-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -269152,7 +269692,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274007,7 +274547,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SYDLG-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -274016,7 +274557,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274033,7 +274574,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SYDLG-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -274042,7 +274584,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274059,7 +274601,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SYDLG-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -274068,7 +274611,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274085,7 +274628,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SYDLG-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -274094,7 +274638,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274111,7 +274655,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SYDLG-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -274120,7 +274665,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274137,7 +274682,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SYDLG-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -274146,7 +274692,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274163,7 +274709,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SYDLG-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -274172,7 +274719,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274189,7 +274736,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SYDLG-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -274198,7 +274746,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274215,7 +274763,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SYDLG-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -274224,7 +274773,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274241,7 +274790,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SYDLG-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -274250,7 +274800,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274267,7 +274817,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-SYDLG-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -274276,7 +274827,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -274293,7 +274844,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-SYDLG-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-SYDLG-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -274302,7 +274854,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281446,7 +281998,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-TADHM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -281455,7 +282008,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281472,7 +282025,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-TADHM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -281481,7 +282035,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281498,7 +282052,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-TADHM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -281507,7 +282062,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281524,7 +282079,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-TADHM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -281533,7 +282089,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281550,7 +282106,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-TADHM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -281559,7 +282116,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281576,7 +282133,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-TADHM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -281585,7 +282143,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281602,7 +282160,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-TADHM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -281611,7 +282170,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281628,7 +282187,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-TADHM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -281637,7 +282197,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281654,7 +282214,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-TADHM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -281663,7 +282224,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281680,7 +282241,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-TADHM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -281689,7 +282251,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281706,7 +282268,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-TADHM-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -281715,7 +282278,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -281732,7 +282295,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-TADHM-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-TADHM-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -281741,7 +282305,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286734,7 +287298,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WADDN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -286743,7 +287308,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286760,7 +287325,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WADDN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -286769,7 +287335,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286786,7 +287352,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WADDN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -286795,7 +287362,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286812,7 +287379,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WADDN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -286821,7 +287389,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286838,7 +287406,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WADDN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -286847,7 +287416,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286864,7 +287433,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WADDN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -286873,7 +287443,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286890,7 +287460,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WADDN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -286899,7 +287470,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286916,7 +287487,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WADDN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -286925,7 +287497,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286942,7 +287514,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WADDN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -286951,7 +287524,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286968,7 +287541,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WADDN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -286977,7 +287551,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -286994,7 +287568,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WADDN-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -287003,7 +287578,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -287020,7 +287595,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WADDN-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WADDN-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -287029,7 +287605,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294451,7 +295027,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WIMPL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -294460,7 +295037,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294477,7 +295054,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WIMPL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -294486,7 +295064,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294503,7 +295081,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WIMPL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -294512,7 +295091,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294529,7 +295108,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WIMPL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -294538,7 +295118,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294555,7 +295135,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WIMPL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -294564,7 +295145,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294581,7 +295162,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WIMPL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -294590,7 +295172,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294607,7 +295189,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WIMPL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -294616,7 +295199,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294633,7 +295216,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WIMPL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -294642,7 +295226,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294659,7 +295243,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WIMPL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -294668,7 +295253,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294685,7 +295270,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WIMPL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -294694,7 +295280,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294711,7 +295297,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WIMPL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -294720,7 +295307,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -294737,7 +295324,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WIMPL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WIMPL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -294746,7 +295334,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302057,7 +302645,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WRTTL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -302066,7 +302655,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302083,7 +302672,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WRTTL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -302092,7 +302682,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302109,7 +302699,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WRTTL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -302118,7 +302709,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302135,7 +302726,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WRTTL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -302144,7 +302736,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302161,7 +302753,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WRTTL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -302170,7 +302763,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302187,7 +302780,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WRTTL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -302196,7 +302790,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302213,7 +302807,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WRTTL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -302222,7 +302817,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302239,7 +302834,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WRTTL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -302248,7 +302844,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302265,7 +302861,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WRTTL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -302274,7 +302871,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302291,7 +302888,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WRTTL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -302300,7 +302898,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302317,7 +302915,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WRTTL-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -302326,7 +302925,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -302343,7 +302942,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WRTTL-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WRTTL-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -302352,7 +302952,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309186,7 +309786,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WYTH1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -309195,7 +309796,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309212,7 +309813,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WYTH1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -309221,7 +309823,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309238,7 +309840,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WYTH1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -309247,7 +309850,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309264,7 +309867,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WYTH1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -309273,7 +309877,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309290,7 +309894,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WYTH1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -309299,7 +309904,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309316,7 +309921,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WYTH1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -309325,7 +309931,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309342,7 +309948,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WYTH1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -309351,7 +309958,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309368,7 +309975,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WYTH1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -309377,7 +309985,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309394,7 +310002,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WYTH1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -309403,7 +310012,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309420,7 +310029,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WYTH1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -309429,7 +310039,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309446,7 +310056,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1DAY_PROCESSED",
+        "COSMOS-WYTH1-PA_1DAY_PROCESSED"
       ],
       "parameters": [
         {
@@ -309455,7 +310066,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",
@@ -309472,7 +310083,8 @@
       "type": "calculate",
       "method": "calculate_D86",
       "dep_ts": [
-        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED"
+        "COSMOS-WYTH1-COSMOS_VWC_1HOUR_PROCESSED",
+        "COSMOS-WYTH1-PA_1HOUR_PROCESSED"
       ],
       "parameters": [
         {
@@ -309481,7 +310093,7 @@
         },
         {
           "param": "round",
-          "value": 5
+          "value": 1
         },
         {
           "param": "annotation",


### PR DESCRIPTION
The d86 method has been updated since the orginal configs for this went in. 

The new method uses Air Pressure (PA) as a dependency, and should only be reported to 1 decimal place. 